### PR TITLE
fix(button): added correct focus-visible style #47

### DIFF
--- a/tedi/components/buttons/button/button.component.scss
+++ b/tedi/components/buttons/button/button.component.scss
@@ -5,10 +5,10 @@ $neutral-variants: "neutral", "neutral-inverted", "danger-neutral";
 @mixin button-variant-color-vars($variant, $icon-only: false, $affix: main) {
   & {
     @if $icon-only {
-      --_btn-bg: var(
-        --button-#{$affix}-#{$variant}-icon-only-background-default
-      );
-    } @else {
+      --_btn-bg: var(--button-#{$affix}-#{$variant}-icon-only-background-default);
+    }
+
+    @else {
       --_btn-bg: var(--button-#{$affix}-#{$variant}-background-default);
     }
 
@@ -23,33 +23,25 @@ $neutral-variants: "neutral", "neutral-inverted", "danger-neutral";
   }
 }
 
-@mixin button-state-color-vars(
-  $variant,
+@mixin button-state-color-vars($variant,
   $state,
   $icon-only: false,
-  $affix: main
-) {
+  $affix: main) {
   & {
     @if $icon-only {
-      --_btn-#{$state}-bg: var(
-        --button-#{$affix}-#{$variant}-icon-only-background-#{$state},
-        var(--button-#{$affix}-#{$variant}-icon-only-background-default)
-      );
-    } @else {
-      --_btn-#{$state}-bg: var(
-        --button-#{$affix}-#{$variant}-background-#{$state},
-        var(--button-#{$affix}-#{$variant}-background-default)
-      );
+      --_btn-#{$state}-bg: var(--button-#{$affix}-#{$variant}-icon-only-background-#{$state},
+        var(--button-#{$affix}-#{$variant}-icon-only-background-default));
     }
 
-    --_btn-#{$state}-border: var(
-      --button-#{$affix}-#{$variant}-border-#{$state},
-      var(--button-#{$affix}-#{$variant}-border-default)
-    );
-    --_btn-#{$state}-text: var(
-      --button-#{$affix}-#{$variant}-text-#{$state},
-      var(--button-#{$affix}-#{$variant}-text-default)
-    );
+    @else {
+      --_btn-#{$state}-bg: var(--button-#{$affix}-#{$variant}-background-#{$state},
+        var(--button-#{$affix}-#{$variant}-background-default));
+    }
+
+    --_btn-#{$state}-border: var(--button-#{$affix}-#{$variant}-border-#{$state},
+      var(--button-#{$affix}-#{$variant}-border-default));
+    --_btn-#{$state}-text: var(--button-#{$affix}-#{$variant}-text-#{$state},
+      var(--button-#{$affix}-#{$variant}-text-default));
   }
 }
 
@@ -60,7 +52,9 @@ $neutral-variants: "neutral", "neutral-inverted", "danger-neutral";
     @if list.index($neutral-variants, $variant) {
       --_btn-disabled-bg: var(--button-main-disabled-neutral-background);
       --_btn-disabled-border: var(--button-main-disabled-neutral-border);
-    } @else {
+    }
+
+    @else {
       --_btn-disabled-bg: var(--button-main-disabled-general-background);
       --_btn-disabled-border: var(--button-main-disabled-general-border);
     }
@@ -68,8 +62,7 @@ $neutral-variants: "neutral", "neutral-inverted", "danger-neutral";
 }
 
 @mixin button-size-vars($size) {
-  --_btn-padding: calc(var(--_btn-padding-y) - 1px)
-    calc(var(--_btn-padding-x) - 1px);
+  --_btn-padding: calc(var(--_btn-padding-y) - 1px) calc(var(--_btn-padding-x) - 1px);
   --_btn-inner-spacing: var(--button-#{$size}-inner-spacing);
   --_btn-padding-y: var(--button-#{$size}-padding-y);
   --_btn-padding-x: var(--button-#{$size}-padding-x);
@@ -80,6 +73,7 @@ $neutral-variants: "neutral", "neutral-inverted", "danger-neutral";
     --_btn-padding-y: var(--button-sm-neutral-padding-y);
     --_btn-padding-x: var(--button-sm-neutral-padding-x);
   }
+
   &:where(.tedi-button--default) {
     --_btn-padding-y: var(--button-md-neutral-padding-y);
     --_btn-padding-x: var(--button-md-neutral-padding-x);
@@ -112,22 +106,14 @@ $neutral-variants: "neutral", "neutral-inverted", "danger-neutral";
     }
 
     &--pl {
-      &:not(.tedi-button--neutral):not(.tedi-button--danger-neutral):not(
-          .tedi-button--neutral-inverted
-        ) {
-        padding-left: calc(
-          var(--_btn-padding-x) + var(--_btn-inner-spacing) - 1px
-        );
+      &:not(.tedi-button--neutral):not(.tedi-button--danger-neutral):not(.tedi-button--neutral-inverted) {
+        padding-left: calc(var(--_btn-padding-x) + var(--_btn-inner-spacing) - 1px);
       }
     }
 
     &--pr {
-      &:not(.tedi-button--neutral):not(.tedi-button--danger-neutral):not(
-          .tedi-button--neutral-inverted
-        ) {
-        padding-right: calc(
-          var(--_btn-padding-x) + var(--_btn-inner-spacing) - 1px
-        );
+      &:not(.tedi-button--neutral):not(.tedi-button--danger-neutral):not(.tedi-button--neutral-inverted) {
+        padding-right: calc(var(--_btn-padding-x) + var(--_btn-inner-spacing) - 1px);
       }
     }
 
@@ -220,6 +206,11 @@ $neutral-variants: "neutral", "neutral-inverted", "danger-neutral";
   &--neutral-inverted {
     @include button-variant-color-vars("neutral-inverted");
     @include neutral-button-padding-overrides;
+  }
+
+  &[class*="-inverted"]:focus-visible {
+    outline: none;
+    box-shadow: 0 0 0 1px var(--tedi-neutral-100), 0 0 0 3px var(--_btn-outline);
   }
 
   &--icon-only {


### PR DESCRIPTION
Inverted buttons must have dual color outline for focus-visible state which cannot be done with outline, must use box-shadow (also defined in Figma)