### PR TITLE
fix(datepicker)

### DIFF
--- a/tedi/components/form/date-picker/date-picker.component.scss
+++ b/tedi/components/form/date-picker/date-picker.component.scss
@@ -51,6 +51,7 @@ tedi-date-picker {
     color: var(--form-input-text-filled);
     border: 0;
     border-radius: var(--form-field-radius);
+    min-width: 0;
 
     &::placeholder {
       color: var(--form-input-text-placeholder);
@@ -67,6 +68,7 @@ tedi-date-picker {
     align-items: center;
     align-self: center;
     justify-content: center;
+    min-width: 0;
   }
 
   &__clear {

--- a/tedi/components/form/date-picker/date-picker.component.scss
+++ b/tedi/components/form/date-picker/date-picker.component.scss
@@ -46,12 +46,12 @@ tedi-date-picker {
 .tedi-date-picker {
   &__input {
     flex: 1;
+    min-width: 0;
     padding-left: var(--form-field-padding-x-md-default);
     font-size: var(--body-regular-size);
     color: var(--form-input-text-filled);
     border: 0;
     border-radius: var(--form-field-radius);
-    min-width: 0;
 
     &::placeholder {
       color: var(--form-input-text-placeholder);

--- a/tedi/components/form/date-picker/date-picker.stories.ts
+++ b/tedi/components/form/date-picker/date-picker.stories.ts
@@ -256,3 +256,27 @@ export const WithReactiveForms: StoryObj<DatePickerComponent> = {
     };
   },
 };
+
+export const WithLowWidth: StoryObj<DatePickerComponent> = {
+  render: (args) => {
+    return {
+      template: `
+        <div style="display: grid; gap: 1rem; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));">
+          <tedi-date-picker ${argsToTemplate(args)}
+            inputPlaceholder="Select a date..."
+          />
+          <tedi-date-picker ${argsToTemplate(args)}
+            inputPlaceholder="Select a date..."
+          />
+          <tedi-date-picker ${argsToTemplate(args)}
+            inputPlaceholder="Select a date..."
+          />
+          <tedi-date-picker ${argsToTemplate(args)}
+            inputPlaceholder="Select a date..."
+          />
+        </div>
+
+      `,
+    };
+  },
+};


### PR DESCRIPTION
datepicker in specific cases could fail to contain the icons when in a grid and in a small-width situation, overriding min-width: auto fixes this issue, also adds a relevant case on storybook
https://artur-langl.github.io/angular/fix/datepicker/?path=/docs/tedi-ready-components-form-datepicker--docs