### PR TITLE
feat(modal): completed modal tedi-ready development #223

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -6,7 +6,7 @@
   ],
   "rules": {
     "selector-class-pattern": [
-      "^(tedi-[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*)*(?:--[a-z][a-z0-9]+(?:-[a-z0-9]+)*)?|ng-[a-z]+(?:-[a-z]+)*|float-ui-[a-z]+(?:-[a-z]+)*)$",
+      "^((tedi|cdk)-[a-z][a-z0-9]*(?:-[a-z0-9]+)*(?:__[a-z][a-z0-9]*(?:-[a-z0-9]+)*)*(?:--[a-z][a-z0-9]+(?:-[a-z0-9]+)*)?|ng-[a-z]+(?:-[a-z]+)*|float-ui-[a-z]+(?:-[a-z]+)*)$",
       {
         "message": "Class selector must start with 'tedi-' prefix and follow BEM naming (e.g., .tedi-button, .tedi-button__icon, .tedi-button--primary). Selector: \"%s\"",
         "resolveNestedSelectors": true

--- a/jest-jsdom-env.ts
+++ b/jest-jsdom-env.ts
@@ -1,0 +1,25 @@
+import JestEnvironment from "jest-preset-angular/environments/jest-jsdom-env";
+import type { JestEnvironmentConfig, EnvironmentContext } from "@jest/environment";
+
+/**
+ * Custom jest environment that suppresses jsdom "Could not parse CSS stylesheet"
+ * errors. These occur because jsdom <22 does not support CSS @layer rules used
+ * by Angular CDK overlay styles.
+ */
+export default class PatchedJsdomEnvironment extends JestEnvironment {
+  constructor(config: JestEnvironmentConfig, context: EnvironmentContext) {
+    const originalError = context.console.error.bind(context.console);
+    context.console.error = (...args: Parameters<typeof console.error>) => {
+      const first = args[0];
+      if (
+        first instanceof Error &&
+        first.message === "Could not parse CSS stylesheet"
+      ) {
+        return;
+      }
+      originalError(...args);
+    };
+
+    super(config, context);
+  }
+}

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,7 +12,7 @@ export default {
   testPathIgnorePatterns: ["/node_modules/", "/dist/"],
   moduleFileExtensions: ["ts", "html", "js", "json"],
   resolver: "jest-preset-angular/build/resolvers/ng-jest-resolver.js",
-  testEnvironment: "jsdom",
+  testEnvironment: "<rootDir>/jest-jsdom-env.ts",
   collectCoverage: true,
   collectCoverageFrom: ["./tedi/components/**/*.{js,ts,tsx}"],
   coveragePathIgnorePatterns: ["\\.stories\\.ts$"],

--- a/tedi/components/helpers/index.ts
+++ b/tedi/components/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from "./grid";
+export * from "./scroll-fade";
 export * from "./separator/separator.component";
 export * from "./timeline";

--- a/tedi/components/helpers/scroll-fade/index.ts
+++ b/tedi/components/helpers/scroll-fade/index.ts
@@ -1,0 +1,2 @@
+export { ScrollFadeComponent } from "./scroll-fade.component";
+export type { ScrollFadeSize, ScrollFadePosition, ScrollFadeScrollbar } from "./scroll-fade.component";

--- a/tedi/components/helpers/scroll-fade/scroll-fade.component.html
+++ b/tedi/components/helpers/scroll-fade/scroll-fade.component.html
@@ -1,0 +1,3 @@
+<div #inner [class]="innerClasses()" (scroll)="onScroll()">
+  <ng-content />
+</div>

--- a/tedi/components/helpers/scroll-fade/scroll-fade.component.scss
+++ b/tedi/components/helpers/scroll-fade/scroll-fade.component.scss
@@ -1,0 +1,56 @@
+$percentages: (0, 10, 20);
+
+.tedi-scroll-fade {
+  --_tedi-scroll-fade-top: 0%;
+  --_tedi-scroll-fade-bottom: 0%;
+
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  max-height: inherit;
+  overflow: hidden;
+
+  &__inner {
+    flex: 1;
+    min-height: 0;
+    max-height: inherit;
+    overflow: auto;
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0%,
+      black var(--_tedi-scroll-fade-top),
+      black calc(100% - var(--_tedi-scroll-fade-bottom)),
+      transparent 100%
+    );
+
+    &--custom-scroll {
+      &::-webkit-scrollbar {
+        width: 6px;
+        background-color: var(--general-surface-primary);
+      }
+
+      &::-webkit-scrollbar-thumb {
+        background: var(--general-border-primary);
+        border-radius: 100px;
+
+        &:hover {
+          background-color: var(--general-border-secondary);
+        }
+      }
+
+      &::-webkit-scrollbar-track {
+        background-color: var(--general-surface-primary);
+      }
+    }
+  }
+
+  @each $percentage in $percentages {
+    &--top-#{$percentage} {
+      --_tedi-scroll-fade-top: calc(#{$percentage} * 1%);
+    }
+
+    &--bottom-#{$percentage} {
+      --_tedi-scroll-fade-bottom: calc(#{$percentage} * 1%);
+    }
+  }
+}

--- a/tedi/components/helpers/scroll-fade/scroll-fade.component.spec.ts
+++ b/tedi/components/helpers/scroll-fade/scroll-fade.component.spec.ts
@@ -1,0 +1,185 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { Component } from "@angular/core";
+import { ScrollFadeComponent } from "./scroll-fade.component";
+
+@Component({
+  standalone: true,
+  imports: [ScrollFadeComponent],
+  template: `
+    <tedi-scroll-fade
+      [fadeSize]="fadeSize"
+      [fadePosition]="fadePosition"
+      [scrollBar]="scrollBar"
+      (scrolledToTop)="onScrolledToTop()"
+      (scrolledToBottom)="onScrolledToBottom()"
+    >
+      <div [style.height.px]="contentHeight">Content</div>
+    </tedi-scroll-fade>
+  `,
+})
+class TestHostComponent {
+  fadeSize: 0 | 10 | 20 = 20;
+  fadePosition: "top" | "bottom" | "both" = "both";
+  scrollBar: "default" | "custom" = "custom";
+  contentHeight = 100;
+  onScrolledToTop = jest.fn();
+  onScrolledToBottom = jest.fn();
+}
+
+describe("ScrollFadeComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let scrollFadeEl: HTMLElement;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+    scrollFadeEl = fixture.nativeElement.querySelector("tedi-scroll-fade");
+  });
+
+  it("should render with default classes", () => {
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade")).toBe(true);
+  });
+
+  it("should render children content", () => {
+    expect(scrollFadeEl.textContent).toContain("Content");
+  });
+
+  it("should have inner wrapper element", () => {
+    const inner = scrollFadeEl.querySelector(".tedi-scroll-fade__inner");
+    expect(inner).toBeTruthy();
+  });
+
+  it("should apply custom scrollbar class by default", () => {
+    const inner = scrollFadeEl.querySelector(".tedi-scroll-fade__inner");
+    expect(inner?.classList.contains("tedi-scroll-fade__inner--custom-scroll")).toBe(true);
+  });
+
+  it("should not apply custom scrollbar class when scrollBar is default", () => {
+    host.scrollBar = "default";
+    fixture.detectChanges();
+    const inner = scrollFadeEl.querySelector(".tedi-scroll-fade__inner");
+    expect(inner?.classList.contains("tedi-scroll-fade__inner--custom-scroll")).toBe(false);
+  });
+
+  it("should not show fade when content does not overflow", () => {
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-20")).toBe(false);
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-20")).toBe(false);
+  });
+
+  it("should respect fadePosition top — never adds bottom fade class", () => {
+    host.fadePosition = "top";
+    fixture.detectChanges();
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-20")).toBe(false);
+  });
+
+  it("should respect fadePosition bottom — never adds top fade class", () => {
+    host.fadePosition = "bottom";
+    fixture.detectChanges();
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-20")).toBe(false);
+  });
+
+  it("should use fadeSize 10 in class names", () => {
+    host.fadeSize = 10;
+    fixture.detectChanges();
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-10")).toBe(false);
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-10")).toBe(false);
+  });
+
+  it("should use fadeSize 0 in class names", () => {
+    host.fadeSize = 0;
+    fixture.detectChanges();
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-0")).toBe(false);
+    expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-0")).toBe(false);
+  });
+
+  describe("with overflowing content", () => {
+    let innerEl: HTMLElement;
+
+    beforeEach(() => {
+      innerEl = scrollFadeEl.querySelector(".tedi-scroll-fade__inner")!;
+
+      Object.defineProperty(innerEl, "scrollHeight", { value: 500, configurable: true });
+      Object.defineProperty(innerEl, "clientHeight", { value: 200, configurable: true });
+      Object.defineProperty(innerEl, "scrollTop", { value: 0, writable: true, configurable: true });
+    });
+
+    it("should show bottom fade when content overflows and scrolled to top", () => {
+      innerEl.dispatchEvent(new Event("scroll"));
+      fixture.detectChanges();
+
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-20")).toBe(false);
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-20")).toBe(true);
+    });
+
+    it("should show both fades when scrolled to middle", () => {
+      Object.defineProperty(innerEl, "scrollTop", { value: 100, configurable: true });
+      innerEl.dispatchEvent(new Event("scroll"));
+      fixture.detectChanges();
+
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-20")).toBe(true);
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-20")).toBe(true);
+    });
+
+    it("should show only top fade when scrolled to bottom", () => {
+      Object.defineProperty(innerEl, "scrollTop", { value: 300, configurable: true });
+      innerEl.dispatchEvent(new Event("scroll"));
+      fixture.detectChanges();
+
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-20")).toBe(true);
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-20")).toBe(false);
+    });
+
+    it("should emit scrolledToTop when at top", () => {
+      innerEl.dispatchEvent(new Event("scroll"));
+      expect(host.onScrolledToTop).toHaveBeenCalled();
+    });
+
+    it("should emit scrolledToBottom when at bottom", () => {
+      Object.defineProperty(innerEl, "scrollTop", { value: 300, configurable: true });
+      innerEl.dispatchEvent(new Event("scroll"));
+      expect(host.onScrolledToBottom).toHaveBeenCalled();
+    });
+
+    it("should not emit scrolledToTop when in middle", () => {
+      host.onScrolledToTop.mockClear();
+      Object.defineProperty(innerEl, "scrollTop", { value: 100, configurable: true });
+      innerEl.dispatchEvent(new Event("scroll"));
+      expect(host.onScrolledToTop).not.toHaveBeenCalled();
+    });
+
+    it("should not emit scrolledToBottom when in middle", () => {
+      host.onScrolledToBottom.mockClear();
+      Object.defineProperty(innerEl, "scrollTop", { value: 100, configurable: true });
+      innerEl.dispatchEvent(new Event("scroll"));
+      expect(host.onScrolledToBottom).not.toHaveBeenCalled();
+    });
+
+    it("should only show top fade when fadePosition is top and scrolled to middle", () => {
+      host.fadePosition = "top";
+      fixture.detectChanges();
+      Object.defineProperty(innerEl, "scrollTop", { value: 100, configurable: true });
+      innerEl.dispatchEvent(new Event("scroll"));
+      fixture.detectChanges();
+
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-20")).toBe(true);
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-20")).toBe(false);
+    });
+
+    it("should only show bottom fade when fadePosition is bottom and scrolled to middle", () => {
+      host.fadePosition = "bottom";
+      fixture.detectChanges();
+      Object.defineProperty(innerEl, "scrollTop", { value: 100, configurable: true });
+      innerEl.dispatchEvent(new Event("scroll"));
+      fixture.detectChanges();
+
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--top-20")).toBe(false);
+      expect(scrollFadeEl.classList.contains("tedi-scroll-fade--bottom-20")).toBe(true);
+    });
+  });
+});

--- a/tedi/components/helpers/scroll-fade/scroll-fade.component.ts
+++ b/tedi/components/helpers/scroll-fade/scroll-fade.component.ts
@@ -1,0 +1,100 @@
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ViewEncapsulation,
+  computed,
+  input,
+  output,
+  signal,
+  viewChild,
+} from "@angular/core";
+
+export type ScrollFadeSize = 0 | 10 | 20;
+export type ScrollFadePosition = "top" | "bottom" | "both";
+export type ScrollFadeScrollbar = "default" | "custom";
+
+@Component({
+  standalone: true,
+  selector: "tedi-scroll-fade",
+  templateUrl: "./scroll-fade.component.html",
+  styleUrl: "./scroll-fade.component.scss",
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    "[class]": "classes()",
+  },
+})
+export class ScrollFadeComponent implements AfterViewInit {
+  /** Size of the fade gradient in percentages. */
+  readonly fadeSize = input<ScrollFadeSize>(20);
+
+  /** Which edges show the fade. */
+  readonly fadePosition = input<ScrollFadePosition>("both");
+
+  /** Scrollbar style. */
+  readonly scrollBar = input<ScrollFadeScrollbar>("custom");
+
+  /** Emitted when scrolled to the top. */
+  readonly scrolledToTop = output<void>();
+
+  /** Emitted when scrolled to the bottom. */
+  readonly scrolledToBottom = output<void>();
+
+  private readonly innerRef = viewChild.required<ElementRef<HTMLDivElement>>("inner");
+
+  private readonly fade = signal({ top: false, bottom: false });
+
+  readonly classes = computed(() => {
+    const classList = ["tedi-scroll-fade"];
+    const { top, bottom } = this.fade();
+    const pos = this.fadePosition();
+    const size = this.fadeSize();
+
+    if (top && (pos === "both" || pos === "top")) {
+      classList.push(`tedi-scroll-fade--top-${size}`);
+    }
+
+    if (bottom && (pos === "both" || pos === "bottom")) {
+      classList.push(`tedi-scroll-fade--bottom-${size}`);
+    }
+
+    return classList.join(" ");
+  });
+
+  readonly innerClasses = computed(() => {
+    const classList = ["tedi-scroll-fade__inner"];
+
+    if (this.scrollBar() === "custom") {
+      classList.push("tedi-scroll-fade__inner--custom-scroll");
+    }
+
+    return classList.join(" ");
+  });
+
+  onScroll(): void {
+    const el = this.innerRef().nativeElement;
+    this.updateFade(el.scrollTop, el.scrollHeight, el.clientHeight);
+  }
+
+  ngAfterViewInit(): void {
+    const el = this.innerRef().nativeElement;
+    this.updateFade(el.scrollTop, el.scrollHeight, el.clientHeight);
+  }
+
+  private updateFade(scrollTop: number, scrollHeight: number, clientHeight: number): void {
+    const atTop = scrollTop === 0;
+    const atBottom = Math.abs(scrollHeight - scrollTop - clientHeight) <= 1;
+
+    if (atTop) {
+      this.scrolledToTop.emit();
+    }
+
+    if (atBottom) {
+      this.scrolledToBottom.emit();
+    }
+
+    this.fade.set({ top: !atTop, bottom: !atBottom });
+  }
+}

--- a/tedi/components/helpers/scroll-fade/scroll-fade.stories.ts
+++ b/tedi/components/helpers/scroll-fade/scroll-fade.stories.ts
@@ -1,0 +1,145 @@
+import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
+import { ScrollFadeComponent } from "./scroll-fade.component";
+import { ColComponent } from "../grid/col/col.component";
+import { RowComponent } from "../grid/row/row.component";
+
+/**
+ * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.39.64?node-id=10758-111141&m=dev" target="_blank">Figma ↗</a><br>
+ * <a href="https://www.tedi.ee/1ee8444b7/p/32b155-scroll-fade" target="_blank">Zeroheight ↗</a>
+ */
+
+const loremIpsum = `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
+  magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris Lorem ipsum dolor sit amet,
+  consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.`;
+
+export default {
+  title: "TEDI-Ready/Components/Helpers/ScrollFade",
+  component: ScrollFadeComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [ScrollFadeComponent, RowComponent, ColComponent],
+    }),
+  ],
+  parameters: {
+    status: {
+      type: ["devComponent"],
+    },
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-(work-in-progress)?node-id=10758-111142&m=dev",
+    },
+  },
+} as Meta<ScrollFadeComponent>;
+
+type Story = StoryObj<ScrollFadeComponent>;
+
+export const Default: Story = {
+  render: (args) => ({
+    props: { ...args, content: loremIpsum },
+    template: `
+      <div style="max-width: 200px; max-height: 200px;">
+        <tedi-scroll-fade [scrollBar]="scrollBar" [fadeSize]="fadeSize" [fadePosition]="fadePosition">
+          {{ content }}
+        </tedi-scroll-fade>
+      </div>
+    `,
+  }),
+  args: {
+    scrollBar: "custom",
+    fadeSize: 20,
+    fadePosition: "both",
+  },
+};
+
+export const Scrollbar: Story = {
+  render: (args) => ({
+    props: { ...args, content: loremIpsum },
+    template: `
+      <tedi-row [gap]="5">
+        <tedi-col [xs]="3">
+          <strong>Default Scrollbar</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade scrollBar="default">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+        <tedi-col [xs]="3">
+          <strong>Custom Scrollbar</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade scrollBar="custom">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const FadeSize: Story = {
+  render: (args) => ({
+    props: { ...args, content: loremIpsum },
+    template: `
+      <tedi-row [gap]="5">
+        <tedi-col [xs]="3">
+          <strong>No Fade (0%)</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade [fadeSize]="0">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+        <tedi-col [xs]="3">
+          <strong>Small Fade (10%)</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade [fadeSize]="10">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+        <tedi-col [xs]="3">
+          <strong>Large Fade (20%)</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade [fadeSize]="20">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const FadePosition: Story = {
+  render: (args) => ({
+    props: { ...args, content: loremIpsum },
+    template: `
+      <tedi-row [gap]="5">
+        <tedi-col [xs]="3">
+          <strong>Top</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade fadePosition="top">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+        <tedi-col [xs]="3">
+          <strong>Bottom</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade fadePosition="bottom">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+        <tedi-col [xs]="3">
+          <strong>Both</strong>
+          <div style="margin-top: 16px; max-width: 200px; max-height: 200px;">
+            <tedi-scroll-fade fadePosition="both">{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const NoFadeWithoutScrollbar: Story = {
+  render: (args) => ({
+    props: { ...args, content: loremIpsum },
+    template: `
+      <tedi-row>
+        <tedi-col [xs]="3">
+          <div style="margin-top: 16px; max-width: 200px; max-height: 400px;">
+            <tedi-scroll-fade>{{ content }}</tedi-scroll-fade>
+          </div>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};

--- a/tedi/components/overlay/modal/index.ts
+++ b/tedi/components/overlay/modal/index.ts
@@ -1,4 +1,7 @@
 export * from "./modal.component";
+export * from "./modal.types";
+export * from "./modal-ref";
+export * from "./modal.service";
 export * from "./modal-content/modal-content.component";
 export * from "./modal-footer/modal-footer.component";
 export * from "./modal-header/modal-header.component";

--- a/tedi/components/overlay/modal/modal-content/modal-content.component.ts
+++ b/tedi/components/overlay/modal/modal-content/modal-content.component.ts
@@ -12,5 +12,8 @@ import {
   styleUrl: "../modal.component.scss",
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tedi-modal-content",
+  },
 })
 export class ModalContentComponent {}

--- a/tedi/components/overlay/modal/modal-footer/modal-footer.component.ts
+++ b/tedi/components/overlay/modal/modal-footer/modal-footer.component.ts
@@ -11,5 +11,8 @@ import {
   styleUrl: "../modal.component.scss",
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tedi-modal-footer",
+  },
 })
 export class ModalFooterComponent {}

--- a/tedi/components/overlay/modal/modal-header/modal-header.component.html
+++ b/tedi/components/overlay/modal/modal-header/modal-header.component.html
@@ -4,4 +4,5 @@
     <button tedi-closing-button (click)="closeModal()"></button>
   }
 </div>
+<ng-content select="[tedi-modal-description]" />
 <ng-content />

--- a/tedi/components/overlay/modal/modal-header/modal-header.component.spec.ts
+++ b/tedi/components/overlay/modal/modal-header/modal-header.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { Component } from "@angular/core";
 import { ModalHeaderComponent } from "./modal-header.component";
 import { ModalComponent } from "../modal.component";
+import { ModalRef } from "../modal-ref";
 import { viewChild } from "@angular/core";
 import { TEDI_TRANSLATION_DEFAULT_TOKEN } from "../../../../tokens/translation.token";
 
@@ -85,5 +86,36 @@ describe("ModalHeaderComponent", () => {
     fixture.detectChanges();
 
     expect(modal.open.set).toHaveBeenCalledWith(false);
+  });
+});
+
+describe("ModalHeaderComponent (service mode)", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let component: ModalHeaderComponent;
+  let mockModalRef: { close: jest.Mock };
+
+  beforeEach(() => {
+    mockModalRef = { close: jest.fn() };
+
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        { provide: ModalComponent, useValue: null },
+        { provide: ModalRef, useValue: mockModalRef },
+        { provide: TEDI_TRANSLATION_DEFAULT_TOKEN, useValue: "et" },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+
+    host = fixture.componentInstance;
+    component = host.header();
+  });
+
+  it("should close via ModalRef when in service mode", () => {
+    component.closeModal();
+    expect(mockModalRef.close).toHaveBeenCalled();
   });
 });

--- a/tedi/components/overlay/modal/modal-header/modal-header.component.ts
+++ b/tedi/components/overlay/modal/modal-header/modal-header.component.ts
@@ -7,6 +7,7 @@ import {
 } from "@angular/core";
 import { ClosingButtonComponent } from "../../../buttons/closing-button/closing-button.component";
 import { ModalComponent } from "../modal.component";
+import { ModalRef } from "../modal-ref";
 
 @Component({
   standalone: true,
@@ -16,14 +17,25 @@ import { ModalComponent } from "../modal.component";
   styleUrl: "../modal.component.scss",
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tedi-modal-header",
+  },
 })
 export class ModalHeaderComponent {
   /** Should show closing button? */
   readonly showClose = input(true);
 
-  private readonly modal = inject(ModalComponent);
+  /** @deprecated Injected when used inside the old template-based tedi-modal. */
+  private readonly modal = inject(ModalComponent, { optional: true });
+
+  /** Injected when opened via ModalService. */
+  private readonly modalRef = inject(ModalRef, { optional: true });
 
   closeModal() {
-    this.modal.open.set(false);
+    if (this.modalRef) {
+      this.modalRef.close();
+    } else if (this.modal) {
+      this.modal.open.set(false);
+    }
   }
 }

--- a/tedi/components/overlay/modal/modal-ref.ts
+++ b/tedi/components/overlay/modal/modal-ref.ts
@@ -1,0 +1,36 @@
+import { Observable } from "rxjs";
+import { DialogRef } from "@angular/cdk/dialog";
+
+/**
+ * Reference to a modal opened via `ModalService`.
+ * Provides methods to close the modal and observe its lifecycle.
+ */
+export class ModalRef<R = unknown> {
+  constructor(private readonly dialogRef: DialogRef<R>) {}
+
+  /** Close the modal, optionally returning a result. */
+  close(result?: R): void {
+    this.dialogRef.close(result);
+  }
+
+  /** Observable that emits when the modal is closed, with the optional result value. */
+  get closed(): Observable<R | undefined> {
+    return this.dialogRef.closed;
+  }
+
+  /** Observable that emits when the backdrop is clicked. */
+  get backdropClick(): Observable<MouseEvent> {
+    return this.dialogRef.backdropClick;
+  }
+
+  /** Observable that emits on keyboard events within the modal. */
+  get keydownEvents(): Observable<KeyboardEvent> {
+    return this.dialogRef.keydownEvents;
+  }
+
+  /** Update the modal's width and height. */
+  updateSize(width?: string, height?: string): this {
+    this.dialogRef.updateSize(width, height);
+    return this;
+  }
+}

--- a/tedi/components/overlay/modal/modal.component.html
+++ b/tedi/components/overlay/modal/modal.component.html
@@ -9,7 +9,7 @@
   [cdkTrapFocus]="!serviceMode"
   [cdkTrapFocusAutoCapture]="!serviceMode && open()"
   [style.display]="serviceMode ? 'contents' : !open() ? 'none' : null"
-  [style.max-width]="customMaxWidth()"
+  [style.width]="customWidth()"
 >
   <ng-content select="tedi-modal-header" />
   <ng-content select="tedi-modal-content" />

--- a/tedi/components/overlay/modal/modal.component.html
+++ b/tedi/components/overlay/modal/modal.component.html
@@ -1,15 +1,17 @@
-@if (open()) {
-  <div class="tedi-modal__backdrop" (click)="open.set(false)"></div>
-  <div
-    class="tedi-modal__dialog"
-    role="dialog"
-    aria-modal="true"
-    tabindex="-1"
-    cdkTrapFocus
-    [cdkTrapFocusAutoCapture]="open()"
-  >
-    <ng-content select="tedi-modal-header" />
-    <ng-content select="tedi-modal-content" />
-    <ng-content select="tedi-modal-footer" />
-  </div>
+@if (!serviceMode && open()) {
+  <div class="tedi-modal__backdrop" (click)="onBackdropClick()"></div>
 }
+<div
+  [class.tedi-modal__dialog]="!serviceMode"
+  [attr.role]="serviceMode ? null : 'dialog'"
+  [attr.aria-modal]="serviceMode ? null : true"
+  [attr.tabindex]="serviceMode ? null : -1"
+  [cdkTrapFocus]="!serviceMode"
+  [cdkTrapFocusAutoCapture]="!serviceMode && open()"
+  [style.display]="serviceMode ? 'contents' : !open() ? 'none' : null"
+  [style.max-width]="customMaxWidth()"
+>
+  <ng-content select="tedi-modal-header" />
+  <ng-content select="tedi-modal-content" />
+  <ng-content select="tedi-modal-footer" />
+</div>

--- a/tedi/components/overlay/modal/modal.component.scss
+++ b/tedi/components/overlay/modal/modal.component.scss
@@ -1,4 +1,5 @@
 @use "@tedi-design-system/core/typography";
+@use "@tedi-design-system/core/bootstrap-utility/breakpoints";
 
 @mixin modal-heading($size) {
   .tedi-modal-header__head {
@@ -14,94 +15,49 @@
   }
 }
 
-$modal-widths: (
-  xs,
-  sm,
-  md,
-  lg,
-  xl
-);
+@mixin modal-size-default {
+  --_tedi-modal-heading-padding-x: var(--modal-heading-padding-x);
+  --_tedi-modal-heading-padding-y: var(--modal-heading-padding-y);
+  --_tedi-modal-body-padding: var(--modal-body-padding);
+  --_tedi-modal-footer-padding-x: var(--modal-footer-padding-x);
+  --_tedi-modal-footer-padding-y: var(--modal-footer-padding-y);
+  --_tedi-modal-footer-gap: var(--button-gutter-x);
 
-.tedi-modal {
-  position: fixed;
-  inset: 0;
-  z-index: var(--z-index-modal);
-  display: none;
+  @include modal-heading(h3);
 
-  &--open {
-    display: block;
+  button[tedi-closing-button] {
+    width: var(--button-sm-icon-size);
+    height: var(--button-sm-icon-size);
   }
+}
 
-  &--default {
-    --_tedi-modal-heading-padding-x: var(--modal-heading-padding-x);
-    --_tedi-modal-heading-padding-y: var(--modal-heading-padding-y);
-    --_tedi-modal-body-padding: var(--modal-body-padding);
-    --_tedi-modal-footer-padding-x: var(--modal-footer-padding-x);
-    --_tedi-modal-footer-padding-y: var(--modal-footer-padding-y);
+@mixin modal-size-small {
+  --_tedi-modal-heading-padding-x: var(--modal-heading-padding-x-sm);
+  --_tedi-modal-heading-padding-y: var(--modal-heading-padding-y-sm);
+  --_tedi-modal-body-padding: var(--modal-body-padding-sm);
+  --_tedi-modal-footer-padding-x: var(--modal-footer-padding-x-sm);
+  --_tedi-modal-footer-padding-y: var(--modal-footer-padding-y-sm);
+  --_tedi-modal-footer-gap: var(--button-gutter-x-sm);
 
-    @include modal-heading(h3);
+  @include modal-heading(h4);
+
+  button[tedi-closing-button] {
+    width: var(--button-xs-icon-size);
+    height: var(--button-xs-icon-size);
   }
+}
 
-  &--small {
-    --_tedi-modal-heading-padding-x: var(--modal-heading-padding-x-sm);
-    --_tedi-modal-heading-padding-y: var(--modal-heading-padding-y-sm);
-    --_tedi-modal-body-padding: var(--modal-body-padding-sm);
-    --_tedi-modal-footer-padding-x: var(--modal-footer-padding-x-sm);
-    --_tedi-modal-footer-padding-y: var(--modal-footer-padding-y-sm);
+@mixin modal-dialog-box {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  background-color: var(--modal-background);
+  border: var(--borders-01) solid var(--modal-border-outer);
+  border-radius: var(--modal-radius);
+}
 
-    @include modal-heading(h4);
-  }
-
-  @each $width in $modal-widths {
-    &--#{$width} {
-      .tedi-modal__dialog {
-        max-width: var(--modal-max-width-#{$width});
-      }
-    }
-  }
-
-  &--center {
-    .tedi-modal__dialog {
-      top: 50%;
-      left: 50%;
-      max-height: 95dvh;
-      transform: translate(-50%, -50%);
-    }
-  }
-
-  &--left {
-    .tedi-modal__dialog {
-      top: 0;
-      left: 0;
-      height: 100%;
-    }
-  }
-
-  &--right {
-    .tedi-modal__dialog {
-      top: 0;
-      right: 0;
-      height: 100%;
-    }
-  }
-
-  &__dialog {
-    position: fixed;
-    display: flex;
-    flex-direction: column;
-    width: 100%;
-    background-color: var(--modal-background);
-    border: var(--borders-01) solid var(--modal-border-outer);
-    border-radius: var(--modal-radius);
-  }
-
-  &__backdrop {
-    position: fixed;
-    inset: 0;
-    background: var(--general-surface-overlay);
-  }
-
-  tedi-modal-header {
+@mixin modal-content-styles {
+  .tedi-modal-header {
     padding: var(--_tedi-modal-heading-padding-y) var(--_tedi-modal-heading-padding-x);
     border-bottom: var(--borders-01) solid var(--modal-border-inner);
 
@@ -114,21 +70,264 @@ $modal-widths: (
         margin-left: auto;
       }
     }
+
+    [tedi-modal-description] {
+      margin-top: var(--layout-grid-gutters-08);
+    }
   }
 
-  tedi-modal-content {
+  .tedi-modal-content {
     display: flex;
+    flex: 1;
     flex-direction: column;
     gap: var(--layout-grid-gutters-16);
     padding: var(--_tedi-modal-body-padding);
     overflow-y: auto;
+
+    &:has(.tedi-scroll-fade) {
+      overflow: hidden;
+    }
+
+    .tedi-scroll-fade {
+      flex: 1;
+      min-height: 0;
+    }
   }
 
-  tedi-modal-footer {
+  .tedi-modal-footer {
     display: flex;
-    gap: var(--layout-grid-gutters-16);
+    gap: var(--_tedi-modal-footer-gap);
     justify-content: flex-end;
     padding: var(--_tedi-modal-footer-padding-y) var(--_tedi-modal-footer-padding-x);
     border-top: var(--borders-01) solid var(--modal-border-inner);
+  }
+}
+
+$modal-widths: (
+  xs,
+  sm,
+  md,
+  lg,
+  xl
+);
+
+// =============================================================================
+// Legacy template-based modal (deprecated)
+// =============================================================================
+
+.tedi-modal {
+  --_tedi-modal-max-width: 95vw;
+  --_tedi-modal-max-height: 95dvh;
+
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-index-modal);
+  display: none;
+
+  &--open {
+    display: block;
+  }
+
+  &--default {
+    @include modal-size-default;
+  }
+
+  &--small {
+    @include modal-size-small;
+  }
+
+  @each $width in $modal-widths {
+    &--#{$width} {
+      .tedi-modal__dialog {
+        max-width: min(var(--modal-max-width-#{$width}), var(--_tedi-modal-max-width));
+      }
+    }
+  }
+
+  &--center {
+    .tedi-modal__dialog {
+      top: 50%;
+      left: 50%;
+      max-height: var(--_tedi-modal-max-height);
+      transform: translate(-50%, -50%);
+    }
+
+    &.tedi-modal--top {
+      .tedi-modal__dialog {
+        top: var(--modal-top-margin);
+        transform: translateX(-50%);
+      }
+    }
+  }
+
+  &--left {
+    .tedi-modal__dialog {
+      top: 0;
+      left: 0;
+      min-height: 100dvh;
+      border-radius: 0;
+      animation: tedi-modal-slide-left 200ms ease-out;
+    }
+  }
+
+  &--right {
+    .tedi-modal__dialog {
+      top: 0;
+      right: 0;
+      min-height: 100dvh;
+      border-radius: 0;
+      animation: tedi-modal-slide-right 200ms ease-out;
+    }
+  }
+
+  &--service {
+    position: static;
+    inset: auto;
+    z-index: auto;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__dialog {
+    position: fixed;
+    max-width: var(--_tedi-modal-max-width);
+
+    @include modal-dialog-box;
+  }
+
+  &__backdrop {
+    position: fixed;
+    inset: 0;
+    background: var(--general-surface-overlay);
+  }
+
+  @include modal-content-styles;
+}
+
+// =============================================================================
+// CDK Dialog-based modal
+// =============================================================================
+
+.cdk-overlay-container {
+  z-index: var(--z-index-modal);
+}
+
+.tedi-modal-backdrop {
+  background: var(--general-surface-overlay);
+}
+
+.tedi-modal-dialog {
+  --_tedi-modal-max-width: 95vw;
+  --_tedi-modal-max-height: 95dvh;
+
+  width: 100%;
+  max-width: var(--_tedi-modal-max-width);
+
+  &--default {
+    @include modal-size-default;
+  }
+
+  &--small {
+    @include modal-size-small;
+  }
+
+  @each $width in $modal-widths {
+    &--#{$width} {
+      max-width: min(var(--modal-max-width-#{$width}), var(--_tedi-modal-max-width));
+    }
+  }
+
+  &--center {
+    max-height: var(--_tedi-modal-max-height);
+  }
+
+  &--left,
+  &--right {
+    min-height: 100dvh;
+
+    // cdk-dialog-container: third-party, can't add host class
+    cdk-dialog-container {
+      min-height: 100dvh;
+    }
+
+    .tedi-modal {
+      min-height: 100dvh;
+      border-radius: 0;
+    }
+  }
+
+  &--left {
+    animation: tedi-modal-slide-left 200ms ease-out;
+  }
+
+  &--right {
+    animation: tedi-modal-slide-right 200ms ease-out;
+  }
+
+  &--center {
+    // cdk-dialog-container: third-party, can't add host class
+    cdk-dialog-container {
+      display: flex;
+      flex-direction: column;
+      max-height: var(--_tedi-modal-max-height);
+    }
+
+    .tedi-modal {
+      max-height: var(--_tedi-modal-max-height);
+      overflow: hidden;
+    }
+  }
+
+  .tedi-modal {
+    @include modal-dialog-box;
+  }
+
+  &--scroll-page {
+    --_tedi-modal-max-height: none;
+
+    .tedi-modal-content {
+      overflow-y: visible;
+    }
+  }
+
+  &--fullscreen-mobile {
+    @include breakpoints.media-breakpoint-down(sm) {
+      --_tedi-modal-max-width: 100vw;
+      --_tedi-modal-max-height: 100dvh;
+
+      min-height: 100dvh;
+
+      // cdk-dialog-container: third-party, can't add host class
+      cdk-dialog-container,
+      .tedi-modal {
+        min-height: 100dvh;
+      }
+
+      .tedi-modal {
+        border-radius: 0;
+      }
+    }
+  }
+
+  @include modal-content-styles;
+}
+
+@keyframes tedi-modal-slide-left {
+  from {
+    transform: translateX(-100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes tedi-modal-slide-right {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
   }
 }

--- a/tedi/components/overlay/modal/modal.component.scss
+++ b/tedi/components/overlay/modal/modal.component.scss
@@ -285,26 +285,54 @@ $modal-widths: (
   &--scroll-page {
     --_tedi-modal-max-height: none;
 
+    cdk-dialog-container {
+      max-height: none;
+    }
+
+    .tedi-modal {
+      max-height: none;
+      overflow: visible;
+    }
+
     .tedi-modal-content {
       overflow-y: visible;
     }
   }
 
-  &--fullscreen-mobile {
-    @include breakpoints.media-breakpoint-down(sm) {
-      --_tedi-modal-max-width: 100vw;
-      --_tedi-modal-max-height: 100dvh;
+  &--fullscreen {
+    --_tedi-modal-max-width: 100vw;
+    --_tedi-modal-max-height: 100dvh;
 
+    max-width: 100vw;
+    min-height: 100dvh;
+
+    cdk-dialog-container,
+    .tedi-modal {
       min-height: 100dvh;
+    }
 
-      // cdk-dialog-container: third-party, can't add host class
-      cdk-dialog-container,
-      .tedi-modal {
+    .tedi-modal {
+      border-radius: 0;
+    }
+  }
+
+  @each $bp in (sm, md, lg, xl) {
+    &--fullscreen-#{$bp} {
+      @include breakpoints.media-breakpoint-down($bp) {
+        --_tedi-modal-max-width: 100vw;
+        --_tedi-modal-max-height: 100dvh;
+
+        max-width: 100vw;
         min-height: 100dvh;
-      }
 
-      .tedi-modal {
-        border-radius: 0;
+        cdk-dialog-container,
+        .tedi-modal {
+          min-height: 100dvh;
+        }
+
+        .tedi-modal {
+          border-radius: 0;
+        }
       }
     }
   }

--- a/tedi/components/overlay/modal/modal.component.scss
+++ b/tedi/components/overlay/modal/modal.component.scss
@@ -252,7 +252,6 @@ $modal-widths: (
 
     .tedi-modal {
       min-height: 100dvh;
-      border-radius: 0;
     }
   }
 
@@ -280,6 +279,13 @@ $modal-widths: (
 
   .tedi-modal {
     @include modal-dialog-box;
+  }
+
+  &--left,
+  &--right {
+    .tedi-modal {
+      border-radius: 0;
+    }
   }
 
   &--scroll-page {

--- a/tedi/components/overlay/modal/modal.component.spec.ts
+++ b/tedi/components/overlay/modal/modal.component.spec.ts
@@ -120,22 +120,22 @@ describe("ModalComponent", () => {
     expect(classes).toContain("tedi-modal--default");
   });
 
-  it("should set max-width style on dialog for custom width", () => {
+  it("should set width style on dialog for custom width", () => {
     fixture.componentRef.setInput("width", "80%");
     fixture.componentRef.setInput("open", true);
     fixture.detectChanges();
 
     const dialog = hostEl.querySelector(".tedi-modal__dialog") as HTMLElement;
-    expect(dialog.style.maxWidth).toBe("80%");
+    expect(dialog.style.width).toBe("80%");
   });
 
-  it("should not set max-width style for preset widths", () => {
+  it("should not set width style for preset widths", () => {
     fixture.componentRef.setInput("width", "lg");
     fixture.componentRef.setInput("open", true);
     fixture.detectChanges();
 
     const dialog = hostEl.querySelector(".tedi-modal__dialog") as HTMLElement;
-    expect(dialog.style.maxWidth).toBe("");
+    expect(dialog.style.width).toBe("");
   });
 
   it("should not apply top class for side positions", () => {

--- a/tedi/components/overlay/modal/modal.component.spec.ts
+++ b/tedi/components/overlay/modal/modal.component.spec.ts
@@ -36,6 +36,7 @@ describe("ModalComponent", () => {
     expect(component.width()).toBe("sm");
     expect(component.position()).toBe("center");
     expect(component.open()).toBe(false);
+    expect(component.closeOnBackdropClick()).toBe(true);
   });
 
   it("should apply correct default classes", () => {
@@ -43,7 +44,11 @@ describe("ModalComponent", () => {
     expect(classes).toContain("tedi-modal--default");
     expect(classes).toContain("tedi-modal--sm");
     expect(classes).toContain("tedi-modal--center");
+    expect(classes).toContain("tedi-modal--sm");
+    expect(classes).toContain("tedi-modal--center");
+    expect(classes).not.toContain("tedi-modal--top");
     expect(classes).not.toContain("tedi-modal--open");
+    expect(classes).not.toContain("tedi-modal--service");
   });
 
   it("should add 'tedi-modal--open' class when opened", () => {
@@ -95,6 +100,73 @@ describe("ModalComponent", () => {
     expect(documentRef.activeElement).toBe(button);
 
     button.remove();
+  });
+
+  it("should apply top and center classes when position is top", () => {
+    fixture.componentRef.setInput("position", "top");
+    fixture.detectChanges();
+
+    const classes = hostEl.getAttribute("class")!;
+    expect(classes).toContain("tedi-modal--top");
+    expect(classes).toContain("tedi-modal--center");
+  });
+
+  it("should not apply width class for custom width values", () => {
+    fixture.componentRef.setInput("width", "80%");
+    fixture.detectChanges();
+
+    const classes = hostEl.getAttribute("class")!;
+    expect(classes).not.toContain("tedi-modal--80%");
+    expect(classes).toContain("tedi-modal--default");
+  });
+
+  it("should set max-width style on dialog for custom width", () => {
+    fixture.componentRef.setInput("width", "80%");
+    fixture.componentRef.setInput("open", true);
+    fixture.detectChanges();
+
+    const dialog = hostEl.querySelector(".tedi-modal__dialog") as HTMLElement;
+    expect(dialog.style.maxWidth).toBe("80%");
+  });
+
+  it("should not set max-width style for preset widths", () => {
+    fixture.componentRef.setInput("width", "lg");
+    fixture.componentRef.setInput("open", true);
+    fixture.detectChanges();
+
+    const dialog = hostEl.querySelector(".tedi-modal__dialog") as HTMLElement;
+    expect(dialog.style.maxWidth).toBe("");
+  });
+
+  it("should not apply top class for side positions", () => {
+    fixture.componentRef.setInput("position", "left");
+    fixture.detectChanges();
+
+    const classes = hostEl.getAttribute("class")!;
+    expect(classes).not.toContain("tedi-modal--top");
+  });
+
+  it("should close on backdrop click by default", () => {
+    fixture.componentRef.setInput("open", true);
+    fixture.detectChanges();
+
+    component.onBackdropClick();
+
+    expect(component.open()).toBe(false);
+  });
+
+  it("should not close on backdrop click when closeOnBackdropClick is false", () => {
+    fixture.componentRef.setInput("open", true);
+    fixture.componentRef.setInput("closeOnBackdropClick", false);
+    fixture.detectChanges();
+
+    component.onBackdropClick();
+
+    expect(component.open()).toBe(true);
+
+    // Cleanup: close modal so body overflow is restored
+    fixture.componentRef.setInput("open", false);
+    fixture.detectChanges();
   });
 });
 

--- a/tedi/components/overlay/modal/modal.component.ts
+++ b/tedi/components/overlay/modal/modal.component.ts
@@ -14,11 +14,23 @@ import {
 } from "@angular/core";
 import { DOCUMENT, isPlatformBrowser } from "@angular/common";
 import { CdkTrapFocus } from "@angular/cdk/a11y";
+import { ModalRef } from "./modal-ref";
+import type {
+  ModalSize,
+  ModalWidth,
+  ModalPosition
+} from "./modal.types";
 
-export type ModalSize = "default" | "small";
-export type ModalWidth = "xs" | "sm" | "md" | "lg" | "xl";
-export type ModalPosition = "center" | "left" | "right";
-
+/**
+ * Modal component that works in two modes:
+ *
+ * **Service mode** When opened via `ModalService.open()`, acts as a
+ * lightweight layout wrapper. CDK Dialog handles overlay, backdrop, focus trap,
+ * scroll blocking, and keyboard events.
+ *
+ * **Standalone mode** (deprecated): When used directly in a template with `[(open)]`,
+ * manages its own overlay, scroll lock, and focus. Migrate to `ModalService.open()`.
+ */
 @Component({
   standalone: true,
   selector: "tedi-modal",
@@ -32,7 +44,7 @@ export type ModalPosition = "center" | "left" | "right";
   },
 })
 export class ModalComponent implements AfterViewInit, OnDestroy {
-  /** Is modal open? */
+  /** @deprecated Is modal open? Only used in standalone (deprecated) mode. */
   readonly open = model(false);
 
   /** Modal size */
@@ -44,29 +56,60 @@ export class ModalComponent implements AfterViewInit, OnDestroy {
   /** Position of the modal */
   readonly position = input<ModalPosition>("center");
 
+  /** @deprecated Whether clicking the backdrop closes the modal. Only used in standalone mode. */
+  readonly closeOnBackdropClick = input(true);
+
   private readonly document = inject(DOCUMENT);
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   private readonly platformId = inject(PLATFORM_ID);
 
+  /**
+   * When a ModalRef is available, this component is inside a CDK Dialog
+   * and should act as a layout-only wrapper.
+   */
+  readonly serviceMode = !!inject(ModalRef, { optional: true });
+
   private prevBodyOverflow: string = "";
   private prevFocusedElement: HTMLElement | null = null;
 
-  readonly classes = computed(() => {
-    const classList = [
-      "tedi-modal",
-      `tedi-modal--${this.size()}`,
-      `tedi-modal--${this.width()}`,
-      `tedi-modal--${this.position()}`,
-    ];
+  private readonly isPresetWidth = computed(() =>
+    (["xs", "sm", "md", "lg", "xl"] as string[]).includes(this.width()),
+  );
 
-    if (this.open()) {
-      classList.push("tedi-modal--open");
+  /** Custom max-width for non-preset widths (legacy mode only). */
+  readonly customMaxWidth = computed(() =>
+    !this.serviceMode && !this.isPresetWidth() ? this.width() : null,
+  );
+
+  readonly classes = computed(() => {
+    const classList = ["tedi-modal"];
+
+    if (this.serviceMode) {
+      classList.push("tedi-modal--service");
+    } else {
+      classList.push(`tedi-modal--${this.size()}`);
+
+      if (this.isPresetWidth()) {
+        classList.push(`tedi-modal--${this.width()}`);
+      }
+
+      if (this.position() === "top") {
+        classList.push("tedi-modal--center", "tedi-modal--top");
+      } else {
+        classList.push(`tedi-modal--${this.position()}`);
+      }
+
+      if (this.open()) {
+        classList.push("tedi-modal--open");
+      }
     }
 
     return classList.join(" ");
   });
 
   constructor() {
+    if (this.serviceMode) return;
+
     effect(() => {
       if (!isPlatformBrowser(this.platformId)) return;
 
@@ -79,12 +122,14 @@ export class ModalComponent implements AfterViewInit, OnDestroy {
   }
 
   ngAfterViewInit(): void {
+    if (this.serviceMode) return;
     if (!isPlatformBrowser(this.platformId)) return;
 
     this.document.body.appendChild(this.host.nativeElement);
   }
 
   ngOnDestroy() {
+    if (this.serviceMode) return;
     if (!isPlatformBrowser(this.platformId)) return;
 
     const element = this.host.nativeElement;
@@ -111,6 +156,13 @@ export class ModalComponent implements AfterViewInit, OnDestroy {
     }
 
     this.document.removeEventListener("keydown", this.handleKeydown);
+  }
+
+  /** @internal */
+  onBackdropClick(): void {
+    if (this.closeOnBackdropClick()) {
+      this.open.set(false);
+    }
   }
 
   private handleKeydown = (e: KeyboardEvent) => {

--- a/tedi/components/overlay/modal/modal.component.ts
+++ b/tedi/components/overlay/modal/modal.component.ts
@@ -76,8 +76,8 @@ export class ModalComponent implements AfterViewInit, OnDestroy {
     (["xs", "sm", "md", "lg", "xl"] as string[]).includes(this.width()),
   );
 
-  /** Custom max-width for non-preset widths (legacy mode only). */
-  readonly customMaxWidth = computed(() =>
+  /** Custom width for non-preset widths (legacy mode only). */
+  readonly customWidth = computed(() =>
     !this.serviceMode && !this.isPresetWidth() ? this.width() : null,
   );
 

--- a/tedi/components/overlay/modal/modal.service.spec.ts
+++ b/tedi/components/overlay/modal/modal.service.spec.ts
@@ -130,22 +130,33 @@ describe("ModalService", () => {
     ref.close();
   });
 
-  it("should apply fullscreen-mobile class when mobileFullscreen is true", () => {
+  it("should apply fullscreen class when fullscreen is true", () => {
     const ref = service.open(TestModalContentComponent, {
-      mobileFullscreen: true,
+      fullscreen: true,
     });
 
     const overlayPane = document.querySelector(".cdk-overlay-pane");
-    expect(overlayPane?.classList.contains("tedi-modal-dialog--fullscreen-mobile")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--fullscreen")).toBe(true);
 
     ref.close();
   });
 
-  it("should not apply fullscreen-mobile class by default", () => {
+  it("should apply fullscreen-md class when fullscreen is 'md'", () => {
+    const ref = service.open(TestModalContentComponent, {
+      fullscreen: "md",
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--fullscreen-md")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should not apply fullscreen class by default", () => {
     const ref = service.open(TestModalContentComponent);
 
     const overlayPane = document.querySelector(".cdk-overlay-pane");
-    expect(overlayPane?.classList.contains("tedi-modal-dialog--fullscreen-mobile")).toBe(false);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--fullscreen")).toBe(false);
 
     ref.close();
   });

--- a/tedi/components/overlay/modal/modal.service.spec.ts
+++ b/tedi/components/overlay/modal/modal.service.spec.ts
@@ -1,0 +1,269 @@
+import { TestBed } from "@angular/core/testing";
+import {
+  Component,
+  inject,
+} from "@angular/core";
+import { ModalService } from "./modal.service";
+import { ModalRef } from "./modal-ref";
+import { MODAL_DATA } from "./modal.types";
+
+@Component({
+  standalone: true,
+  template: `<div class="test-content">{{ data?.message }}</div>`,
+})
+class TestModalContentComponent {
+  data = inject(MODAL_DATA, { optional: true }) as { message: string } | null;
+  ref = inject(ModalRef);
+}
+
+describe("ModalService", () => {
+  let service: ModalService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ModalService);
+  });
+
+  afterEach(() => {
+    service.closeAll();
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+
+  it("should open a modal and return a ModalRef", () => {
+    const ref = service.open(TestModalContentComponent);
+    expect(ref).toBeInstanceOf(ModalRef);
+  });
+
+  it("should pass data to the modal content via MODAL_DATA", () => {
+    const ref = service.open(TestModalContentComponent, {
+      data: { message: "Hello" },
+    });
+
+    expect(ref).toBeTruthy();
+    ref.close();
+  });
+
+  it("should close the modal via ModalRef.close()", (done) => {
+    const ref = service.open(TestModalContentComponent);
+
+    ref.closed.subscribe((result) => {
+      expect(result).toBeUndefined();
+      done();
+    });
+
+    ref.close();
+  });
+
+  it("should return a result when closing", (done) => {
+    const ref = service.open<string>(TestModalContentComponent);
+
+    ref.closed.subscribe((result) => {
+      expect(result).toBe("confirmed");
+      done();
+    });
+
+    ref.close("confirmed");
+  });
+
+  it("should apply correct panel classes for default config", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--default")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--sm")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--center")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--top")).toBe(false);
+
+    ref.close();
+  });
+
+  it("should apply correct panel classes for custom config", () => {
+    const ref = service.open(TestModalContentComponent, {
+      size: "small",
+      width: "lg",
+      position: "right",
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--small")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--lg")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--right")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should apply top and center classes when position is top", () => {
+    const ref = service.open(TestModalContentComponent, {
+      position: "top",
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--top")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--center")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should not apply width class for custom width values", () => {
+    const ref = service.open(TestModalContentComponent, {
+      width: "80%",
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--80%")).toBe(false);
+
+    ref.close();
+  });
+
+  it("should set max-width on overlay element for custom width", () => {
+    const ref = service.open(TestModalContentComponent, {
+      width: "80%",
+    });
+
+    const overlayElement = document.querySelector(".cdk-global-overlay-wrapper .cdk-overlay-pane") as HTMLElement;
+    expect(overlayElement?.style.maxWidth).toBe("80%");
+
+    ref.close();
+  });
+
+  it("should apply fullscreen-mobile class when mobileFullscreen is true", () => {
+    const ref = service.open(TestModalContentComponent, {
+      mobileFullscreen: true,
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--fullscreen-mobile")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should not apply fullscreen-mobile class by default", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--fullscreen-mobile")).toBe(false);
+
+    ref.close();
+  });
+
+  it("should apply backdrop class", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    const backdrop = document.querySelector(".cdk-overlay-backdrop");
+    expect(backdrop?.classList.contains("tedi-modal-backdrop")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should close on Escape by default", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    const event = new KeyboardEvent("keydown", { key: "Escape" });
+    document.querySelector("cdk-dialog-container")?.dispatchEvent(event);
+
+    // The dialog should be closing/closed
+    expect(ref).toBeTruthy();
+    ref.close();
+  });
+
+  it("should not close on Escape when closeOnEscape is false", () => {
+    service.open(TestModalContentComponent, {
+      closeOnEscape: false,
+    });
+
+    const event = new KeyboardEvent("keydown", { key: "Escape" });
+    document.querySelector("cdk-dialog-container")?.dispatchEvent(event);
+
+    // Modal should still be open - overlay pane should exist
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane).toBeTruthy();
+
+    service.closeAll();
+  });
+
+  it("should apply scroll-page class when scrollBehavior is page", () => {
+    const ref = service.open(TestModalContentComponent, {
+      scrollBehavior: "page",
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--scroll-page")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should set overflow and padding on host element for page scroll", () => {
+    const ref = service.open(TestModalContentComponent, {
+      scrollBehavior: "page",
+    });
+
+    const hostElement = document.querySelector(".cdk-global-overlay-wrapper") as HTMLElement;
+    expect(hostElement?.style.overflow).toBe("auto");
+
+    ref.close();
+  });
+
+  it("should apply left position strategy", () => {
+    const ref = service.open(TestModalContentComponent, {
+      position: "left",
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--left")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should apply page scroll position strategy", () => {
+    const ref = service.open(TestModalContentComponent, {
+      scrollBehavior: "page",
+    });
+
+    const overlayPane = document.querySelector(".cdk-overlay-pane");
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--scroll-page")).toBe(true);
+    expect(overlayPane?.classList.contains("tedi-modal-dialog--center")).toBe(true);
+
+    ref.close();
+  });
+
+  it("should expose backdropClick observable on ModalRef", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    expect(ref.backdropClick).toBeDefined();
+    expect(ref.backdropClick.subscribe).toBeDefined();
+
+    ref.close();
+  });
+
+  it("should expose keydownEvents observable on ModalRef", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    expect(ref.keydownEvents).toBeDefined();
+    expect(ref.keydownEvents.subscribe).toBeDefined();
+
+    ref.close();
+  });
+
+  it("should support updateSize on ModalRef", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    const result = ref.updateSize("500px", "300px");
+    expect(result).toBe(ref);
+
+    ref.close();
+  });
+
+  it("should close all modals via closeAll()", () => {
+    service.open(TestModalContentComponent);
+    service.open(TestModalContentComponent);
+
+    service.closeAll();
+
+    const overlayPanes = document.querySelectorAll(".tedi-modal-dialog");
+    expect(overlayPanes.length).toBe(0);
+  });
+});

--- a/tedi/components/overlay/modal/modal.service.spec.ts
+++ b/tedi/components/overlay/modal/modal.service.spec.ts
@@ -119,13 +119,13 @@ describe("ModalService", () => {
     ref.close();
   });
 
-  it("should set max-width on overlay element for custom width", () => {
+  it("should set width on overlay element for custom width", () => {
     const ref = service.open(TestModalContentComponent, {
       width: "80%",
     });
 
     const overlayElement = document.querySelector(".cdk-global-overlay-wrapper .cdk-overlay-pane") as HTMLElement;
-    expect(overlayElement?.style.maxWidth).toBe("80%");
+    expect(overlayElement?.style.width).toBe("80%");
 
     ref.close();
   });
@@ -253,6 +253,26 @@ describe("ModalService", () => {
 
     const result = ref.updateSize("500px", "300px");
     expect(result).toBe(ref);
+
+    ref.close();
+  });
+
+  it("should set --_tedi-modal-max-width CSS variable when maxWidth is provided", () => {
+    const ref = service.open(TestModalContentComponent, {
+      maxWidth: "800px",
+    });
+
+    const overlayElement = document.querySelector(".cdk-global-overlay-wrapper .cdk-overlay-pane") as HTMLElement;
+    expect(overlayElement?.style.getPropertyValue("--_tedi-modal-max-width")).toBe("800px");
+
+    ref.close();
+  });
+
+  it("should not set --_tedi-modal-max-width CSS variable by default", () => {
+    const ref = service.open(TestModalContentComponent);
+
+    const overlayElement = document.querySelector(".cdk-global-overlay-wrapper .cdk-overlay-pane") as HTMLElement;
+    expect(overlayElement?.style.getPropertyValue("--_tedi-modal-max-width")).toBe("");
 
     ref.close();
   });

--- a/tedi/components/overlay/modal/modal.service.ts
+++ b/tedi/components/overlay/modal/modal.service.ts
@@ -1,0 +1,168 @@
+import { Injectable, inject } from "@angular/core";
+import { Dialog, DialogRef } from "@angular/cdk/dialog";
+import { GlobalPositionStrategy, Overlay } from "@angular/cdk/overlay";
+import { ComponentType } from "@angular/cdk/portal";
+import { ModalRef } from "./modal-ref";
+import { ModalConfig, ModalPosition, ModalScrollBehavior, MODAL_DATA } from "./modal.types";
+
+const WIDTH_PRESETS: readonly string[] = ["xs", "sm", "md", "lg", "xl"];
+
+@Injectable({ providedIn: "root" })
+export class ModalService {
+  private readonly dialog = inject(Dialog);
+  private readonly overlay = inject(Overlay);
+
+  /**
+   * Open a modal dialog with the given component as content.
+   *
+   * @param component Component to render inside the modal.
+   * @param config Modal configuration (size, width, position, data, etc.).
+   * @returns A `ModalRef` to control and observe the modal.
+   *
+   * @example
+   * ```ts
+   * const ref = this.modalService.open(MyFormComponent, {
+   *   data: { userId: 123 },
+   *   width: 'md',
+   *   position: 'center',
+   * });
+   *
+   * ref.closed.subscribe(result => console.log('Modal closed with:', result));
+   * ```
+   */
+  open<R = unknown, D = unknown>(
+    component: ComponentType<unknown>,
+    config: ModalConfig<D> = {},
+  ): ModalRef<R> {
+    const {
+      data,
+      size = "default",
+      width = "sm",
+      position = "center",
+      scrollBehavior = "content",
+      closeOnBackdropClick = true,
+      closeOnEscape = true,
+      mobileFullscreen = false,
+      ariaLabel,
+      ariaLabelledBy,
+    } = config;
+
+    const panelClasses = this.buildPanelClasses(size, width, position, scrollBehavior, mobileFullscreen);
+    const isPresetWidth = WIDTH_PRESETS.includes(width);
+
+    const dialogRef = this.dialog.open<R, D>(component, {
+      data,
+      panelClass: panelClasses,
+      backdropClass: "tedi-modal-backdrop",
+      hasBackdrop: true,
+      disableClose: true,
+      ariaLabel,
+      ariaLabelledBy,
+      ariaModal: true,
+      autoFocus: "first-tabbable",
+      restoreFocus: true,
+      positionStrategy: this.buildPositionStrategy(position, scrollBehavior),
+      scrollStrategy: this.overlay.scrollStrategies.block(),
+      providers: (ref) => [
+        { provide: ModalRef, useValue: new ModalRef<R>(ref) },
+        { provide: MODAL_DATA, useValue: data },
+      ],
+    });
+
+    if (!isPresetWidth) {
+      dialogRef.overlayRef.overlayElement.style.maxWidth = width;
+    }
+
+    this.setupDialogBehavior(dialogRef, scrollBehavior, closeOnBackdropClick, closeOnEscape);
+
+    return new ModalRef<R>(dialogRef);
+  }
+
+  /** Close all open modals. */
+  closeAll(): void {
+    this.dialog.closeAll();
+  }
+
+  private buildPanelClasses(
+    size: string,
+    width: string,
+    position: ModalPosition,
+    scrollBehavior: ModalScrollBehavior,
+    mobileFullscreen: boolean,
+  ): string[] {
+    const classes = [
+      "tedi-modal-dialog",
+      `tedi-modal-dialog--${size}`,
+    ];
+
+    if (WIDTH_PRESETS.includes(width)) {
+      classes.push(`tedi-modal-dialog--${width}`);
+    }
+
+    if (position === "top") {
+      classes.push("tedi-modal-dialog--center", "tedi-modal-dialog--top");
+    } else {
+      classes.push(`tedi-modal-dialog--${position}`);
+    }
+
+    if (scrollBehavior === "page") {
+      classes.push("tedi-modal-dialog--scroll-page");
+    }
+
+    if (mobileFullscreen) {
+      classes.push("tedi-modal-dialog--fullscreen-mobile");
+    }
+
+    return classes;
+  }
+
+  private setupDialogBehavior<R>(
+    dialogRef: DialogRef<R>,
+    scrollBehavior: ModalScrollBehavior,
+    closeOnBackdropClick: boolean,
+    closeOnEscape: boolean,
+  ): void {
+    if (scrollBehavior === "page") {
+      const host = dialogRef.overlayRef.hostElement;
+      host.style.overflow = "auto";
+      host.style.paddingBlock = "var(--layout-grid-gutters-16)";
+    }
+
+    if (closeOnBackdropClick) {
+      dialogRef.backdropClick.subscribe(() => dialogRef.close());
+    }
+
+    if (closeOnEscape) {
+      dialogRef.keydownEvents.subscribe((event) => {
+        if (event.key === "Escape") {
+          dialogRef.close();
+        }
+      });
+    }
+  }
+
+  private buildPositionStrategy(
+    position: ModalPosition,
+    scrollBehavior: ModalScrollBehavior,
+  ): GlobalPositionStrategy {
+    const global = this.overlay.position().global();
+
+    if (position === "left") {
+      return global.left("0").top("0");
+    }
+
+    if (position === "right") {
+      return global.right("0").top("0");
+    }
+
+    if (position === "top") {
+      return global.centerHorizontally().top("var(--modal-top-margin)");
+    }
+
+    if (scrollBehavior === "page") {
+      return global.centerHorizontally().top("0");
+    }
+
+    return global.centerHorizontally().centerVertically();
+  }
+}

--- a/tedi/components/overlay/modal/modal.service.ts
+++ b/tedi/components/overlay/modal/modal.service.ts
@@ -3,7 +3,7 @@ import { Dialog, DialogRef } from "@angular/cdk/dialog";
 import { GlobalPositionStrategy, Overlay } from "@angular/cdk/overlay";
 import { ComponentType } from "@angular/cdk/portal";
 import { ModalRef } from "./modal-ref";
-import { ModalConfig, ModalPosition, ModalScrollBehavior, MODAL_DATA } from "./modal.types";
+import { ModalConfig, ModalFullscreen, ModalPosition, ModalScrollBehavior, MODAL_DATA } from "./modal.types";
 
 const WIDTH_PRESETS: readonly string[] = ["xs", "sm", "md", "lg", "xl"];
 
@@ -42,13 +42,13 @@ export class ModalService {
       scrollBehavior = "content",
       closeOnBackdropClick = true,
       closeOnEscape = true,
-      mobileFullscreen = false,
+      fullscreen = false,
       maxWidth,
       ariaLabel,
       ariaLabelledBy,
     } = config;
 
-    const panelClasses = this.buildPanelClasses(size, width, position, scrollBehavior, mobileFullscreen);
+    const panelClasses = this.buildPanelClasses(size, width, position, scrollBehavior, fullscreen);
     const isPresetWidth = WIDTH_PRESETS.includes(width);
 
     const dialogRef = this.dialog.open<R, D>(component, {
@@ -93,7 +93,7 @@ export class ModalService {
     width: string,
     position: ModalPosition,
     scrollBehavior: ModalScrollBehavior,
-    mobileFullscreen: boolean,
+    fullscreen: ModalFullscreen,
   ): string[] {
     const classes = [
       "tedi-modal-dialog",
@@ -114,8 +114,10 @@ export class ModalService {
       classes.push("tedi-modal-dialog--scroll-page");
     }
 
-    if (mobileFullscreen) {
-      classes.push("tedi-modal-dialog--fullscreen-mobile");
+    if (fullscreen === true) {
+      classes.push("tedi-modal-dialog--fullscreen");
+    } else if (typeof fullscreen === "string") {
+      classes.push(`tedi-modal-dialog--fullscreen-${fullscreen}`);
     }
 
     return classes;

--- a/tedi/components/overlay/modal/modal.service.ts
+++ b/tedi/components/overlay/modal/modal.service.ts
@@ -43,6 +43,7 @@ export class ModalService {
       closeOnBackdropClick = true,
       closeOnEscape = true,
       mobileFullscreen = false,
+      maxWidth,
       ariaLabel,
       ariaLabelledBy,
     } = config;
@@ -70,7 +71,11 @@ export class ModalService {
     });
 
     if (!isPresetWidth) {
-      dialogRef.overlayRef.overlayElement.style.maxWidth = width;
+      dialogRef.overlayRef.overlayElement.style.width = width;
+    }
+
+    if (maxWidth) {
+      dialogRef.overlayRef.overlayElement.style.setProperty("--_tedi-modal-max-width", maxWidth);
     }
 
     this.setupDialogBehavior(dialogRef, scrollBehavior, closeOnBackdropClick, closeOnEscape);

--- a/tedi/components/overlay/modal/modal.stories.ts
+++ b/tedi/components/overlay/modal/modal.stories.ts
@@ -1,5 +1,5 @@
 import { type Meta, type StoryObj, moduleMetadata } from "@storybook/angular";
-import { Component, inject } from "@angular/core";
+import { Component, inject, Input } from "@angular/core";
 import { ModalComponent } from "./modal.component";
 import { ModalHeaderComponent } from "./modal-header/modal-header.component";
 import { ModalContentComponent } from "./modal-content/modal-content.component";
@@ -9,23 +9,16 @@ import { ModalRef } from "./modal-ref";
 import { MODAL_DATA } from "./modal.types";
 import { ButtonComponent } from "../../buttons/button/button.component";
 import { LabelComponent } from "../../form/label/label.component";
-import { SelectComponent, SelectOptionComponent } from "@tedi-design-system/angular/community";
 import { IconComponent } from "../../base/icon/icon.component";
 import { ScrollFadeComponent } from "../../helpers/scroll-fade/scroll-fade.component";
-
-const defaultOptions = [
-  { value: "1", label: "Option 1" },
-  { value: "2", label: "Option 2" },
-  { value: "3", label: "Option 3" },
-  { value: "4", label: "Option 4" },
-  { value: "5", label: "Option 5" },
-];
+import { TextFieldComponent } from "../../form/text-field/text-field.component";
+import { FormFieldComponent } from "../../form/form-field/form-field.component";
+import { DatePickerComponent } from "../../form/date-picker/date-picker.component";
 
 interface StoryModalData {
   title: string;
   description?: string;
   showClose?: boolean;
-  options: { value: string; label: string }[];
 }
 
 const sharedModalImports = [
@@ -35,8 +28,8 @@ const sharedModalImports = [
   ModalFooterComponent,
   ButtonComponent,
   LabelComponent,
-  SelectComponent,
-  SelectOptionComponent,
+  TextFieldComponent,
+  FormFieldComponent,
 ];
 
 @Component({
@@ -52,22 +45,14 @@ const sharedModalImports = [
         }
       </tedi-modal-header>
       <tedi-modal-content>
-        <div>
-          <label tedi-label for="select-1">Label</label>
-          <tedi-select inputId="select-1" state="default">
-            @for (option of data.options; track option.value) {
-              <tedi-select-option [value]="option.value" [label]="option.label" />
-            }
-          </tedi-select>
-        </div>
-        <div>
-          <label tedi-label for="select-2">Label</label>
-          <tedi-select inputId="select-2" state="default">
-            @for (option of data.options; track option.value) {
-              <tedi-select-option [value]="option.value" [label]="option.label" />
-            }
-          </tedi-select>
-        </div>
+        <tedi-form-field>
+          <label tedi-label for="field-1">Label</label>
+          <input tedi-text-field id="field-1" />
+        </tedi-form-field>
+        <tedi-form-field>
+          <label tedi-label for="field-2">Label</label>
+          <input tedi-text-field id="field-2" />
+        </tedi-form-field>
       </tedi-modal-content>
       <tedi-modal-footer>
         <button tedi-button variant="secondary" (click)="ref.close('cancel')">Cancel</button>
@@ -84,27 +69,112 @@ class StoryModalContentComponent {
 @Component({
   standalone: true,
   selector: "story-scrollable-content",
-  imports: sharedModalImports,
+  imports: [...sharedModalImports, DatePickerComponent],
   template: `
     <tedi-modal>
       <tedi-modal-header>
         <h1>{{ data.title }}</h1>
       </tedi-modal-header>
       <tedi-modal-content>
-        @for (i of fields; track i) {
+        <h3 style="margin: 0;">Teenus</h3>
+        <tedi-form-field>
+          <label tedi-label for="service">Teenus</label>
+          <input tedi-text-field id="service" />
+        </tedi-form-field>
+        <tedi-form-field>
+          <label tedi-label for="institution">Asutus</label>
+          <input tedi-text-field id="institution" />
+        </tedi-form-field>
+        <tedi-form-field>
+          <label tedi-label for="persons">Isikud</label>
+          <input tedi-text-field id="persons" />
+        </tedi-form-field>
+        <tedi-form-field>
+          <label tedi-label for="priority">Prioriteet</label>
+          <input tedi-text-field id="priority" />
+        </tedi-form-field>
+        <tedi-form-field>
+          <label tedi-label for="description">Probleemi kirjeldus</label>
+          <input tedi-text-field id="description" />
+        </tedi-form-field>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
           <div>
-            <label tedi-label [for]="'select-' + i">Label</label>
-            <tedi-select [inputId]="'select-' + i" state="default">
-              @for (option of data.options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
+            <label tedi-label for="start-date">Alguskuupäev</label>
+            <tedi-date-picker inputId="start-date" />
           </div>
-        }
+          <div>
+            <label tedi-label for="end-date">Lõppkuupäev</label>
+            <tedi-date-picker inputId="end-date" />
+          </div>
+        </div>
+        <hr style="border: none; border-top: 1px solid var(--modal-border-inner); margin: 0;" />
+        <h3 style="margin: 0;">Kontaktisik</h3>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+          <tedi-form-field>
+            <label tedi-label for="contact-first-name">Eesnimi</label>
+            <input tedi-text-field id="contact-first-name" />
+          </tedi-form-field>
+          <tedi-form-field>
+            <label tedi-label for="contact-last-name">Perenimi</label>
+            <input tedi-text-field id="contact-last-name" />
+          </tedi-form-field>
+        </div>
+        <tedi-form-field>
+          <label tedi-label for="contact-id">Isikukood</label>
+          <input tedi-text-field id="contact-id" />
+        </tedi-form-field>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+          <tedi-form-field>
+            <label tedi-label for="contact-phone">Telefon</label>
+            <input tedi-text-field id="contact-phone" type="tel" />
+          </tedi-form-field>
+          <tedi-form-field>
+            <label tedi-label for="contact-email">E-post</label>
+            <input tedi-text-field id="contact-email" type="email" />
+          </tedi-form-field>
+        </div>
+        <tedi-form-field>
+          <label tedi-label for="contact-address">Aadress</label>
+          <input tedi-text-field id="contact-address" />
+        </tedi-form-field>
+        <hr style="border: none; border-top: 1px solid var(--modal-border-inner); margin: 0;" />
+        <h3 style="margin: 0;">Esindaja</h3>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+          <tedi-form-field>
+            <label tedi-label for="rep-first-name">Eesnimi</label>
+            <input tedi-text-field id="rep-first-name" />
+          </tedi-form-field>
+          <tedi-form-field>
+            <label tedi-label for="rep-last-name">Perenimi</label>
+            <input tedi-text-field id="rep-last-name" />
+          </tedi-form-field>
+        </div>
+        <tedi-form-field>
+          <label tedi-label for="rep-id">Isikukood</label>
+          <input tedi-text-field id="rep-id" />
+        </tedi-form-field>
+        <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+          <tedi-form-field>
+            <label tedi-label for="rep-phone">Telefon</label>
+            <input tedi-text-field id="rep-phone" type="tel" />
+          </tedi-form-field>
+          <tedi-form-field>
+            <label tedi-label for="rep-email">E-post</label>
+            <input tedi-text-field id="rep-email" type="email" />
+          </tedi-form-field>
+        </div>
+        <tedi-form-field>
+          <label tedi-label for="rep-address">Aadress</label>
+          <input tedi-text-field id="rep-address" />
+        </tedi-form-field>
+        <tedi-form-field>
+          <label tedi-label for="rep-relation">Seos isikuga</label>
+          <input tedi-text-field id="rep-relation" />
+        </tedi-form-field>
       </tedi-modal-content>
       <tedi-modal-footer>
-        <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
-        <button tedi-button (click)="ref.close()">Save</button>
+        <button tedi-button variant="secondary" (click)="ref.close()">Katkesta</button>
+        <button tedi-button (click)="ref.close()">Lisa</button>
       </tedi-modal-footer>
     </tedi-modal>
   `,
@@ -112,13 +182,12 @@ class StoryModalContentComponent {
 class StoryScrollableContentComponent {
   readonly data = inject(MODAL_DATA) as StoryModalData;
   readonly ref = inject(ModalRef);
-  readonly fields = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 }
 
 @Component({
   standalone: true,
   selector: "story-scrollable-fade-content",
-  imports: [...sharedModalImports, ScrollFadeComponent],
+  imports: [...sharedModalImports, ScrollFadeComponent, DatePickerComponent],
   template: `
     <tedi-modal>
       <tedi-modal-header>
@@ -126,21 +195,108 @@ class StoryScrollableContentComponent {
       </tedi-modal-header>
       <tedi-modal-content>
         <tedi-scroll-fade fadePosition="both" fadeSize="10">
-          @for (i of fields; track i) {
-            <div style="padding: 8px 0;">
-              <label tedi-label [for]="'select-' + i">Label</label>
-              <tedi-select [inputId]="'select-' + i" state="default">
-                @for (option of data.options; track option.value) {
-                  <tedi-select-option [value]="option.value" [label]="option.label" />
-                }
-              </tedi-select>
+          <div style="display: flex; flex-direction: column; gap: 16px; padding: 8px 0;">
+            <h3 style="margin: 0;">Teenus</h3>
+            <tedi-form-field>
+              <label tedi-label for="fade-service">Teenus</label>
+              <input tedi-text-field id="fade-service" />
+            </tedi-form-field>
+            <tedi-form-field>
+              <label tedi-label for="fade-institution">Asutus</label>
+              <input tedi-text-field id="fade-institution" />
+            </tedi-form-field>
+            <tedi-form-field>
+              <label tedi-label for="fade-persons">Isikud</label>
+              <input tedi-text-field id="fade-persons" />
+            </tedi-form-field>
+            <tedi-form-field>
+              <label tedi-label for="fade-priority">Prioriteet</label>
+              <input tedi-text-field id="fade-priority" />
+            </tedi-form-field>
+            <tedi-form-field>
+              <label tedi-label for="fade-description">Probleemi kirjeldus</label>
+              <input tedi-text-field id="fade-description" />
+            </tedi-form-field>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+              <div>
+                <label tedi-label for="fade-start-date">Alguskuupäev</label>
+                <tedi-date-picker inputId="fade-start-date" />
+              </div>
+              <div>
+                <label tedi-label for="fade-end-date">Lõppkuupäev</label>
+                <tedi-date-picker inputId="fade-end-date" />
+              </div>
             </div>
-          }
+            <hr style="border: none; border-top: 1px solid var(--modal-border-inner); margin: 0;" />
+            <h3 style="margin: 0;">Kontaktisik</h3>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+              <tedi-form-field>
+                <label tedi-label for="fade-contact-first-name">Eesnimi</label>
+                <input tedi-text-field id="fade-contact-first-name" />
+              </tedi-form-field>
+              <tedi-form-field>
+                <label tedi-label for="fade-contact-last-name">Perenimi</label>
+                <input tedi-text-field id="fade-contact-last-name" />
+              </tedi-form-field>
+            </div>
+            <tedi-form-field>
+              <label tedi-label for="fade-contact-id">Isikukood</label>
+              <input tedi-text-field id="fade-contact-id" />
+            </tedi-form-field>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+              <tedi-form-field>
+                <label tedi-label for="fade-contact-phone">Telefon</label>
+                <input tedi-text-field id="fade-contact-phone" type="tel" />
+              </tedi-form-field>
+              <tedi-form-field>
+                <label tedi-label for="fade-contact-email">E-post</label>
+                <input tedi-text-field id="fade-contact-email" type="email" />
+              </tedi-form-field>
+            </div>
+            <tedi-form-field>
+              <label tedi-label for="fade-contact-address">Aadress</label>
+              <input tedi-text-field id="fade-contact-address" />
+            </tedi-form-field>
+            <hr style="border: none; border-top: 1px solid var(--modal-border-inner); margin: 0;" />
+            <h3 style="margin: 0;">Esindaja</h3>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+              <tedi-form-field>
+                <label tedi-label for="fade-rep-first-name">Eesnimi</label>
+                <input tedi-text-field id="fade-rep-first-name" />
+              </tedi-form-field>
+              <tedi-form-field>
+                <label tedi-label for="fade-rep-last-name">Perenimi</label>
+                <input tedi-text-field id="fade-rep-last-name" />
+              </tedi-form-field>
+            </div>
+            <tedi-form-field>
+              <label tedi-label for="fade-rep-id">Isikukood</label>
+              <input tedi-text-field id="fade-rep-id" />
+            </tedi-form-field>
+            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 16px;">
+              <tedi-form-field>
+                <label tedi-label for="fade-rep-phone">Telefon</label>
+                <input tedi-text-field id="fade-rep-phone" type="tel" />
+              </tedi-form-field>
+              <tedi-form-field>
+                <label tedi-label for="fade-rep-email">E-post</label>
+                <input tedi-text-field id="fade-rep-email" type="email" />
+              </tedi-form-field>
+            </div>
+            <tedi-form-field>
+              <label tedi-label for="fade-rep-address">Aadress</label>
+              <input tedi-text-field id="fade-rep-address" />
+            </tedi-form-field>
+            <tedi-form-field>
+              <label tedi-label for="fade-rep-relation">Seos isikuga</label>
+              <input tedi-text-field id="fade-rep-relation" />
+            </tedi-form-field>
+          </div>
         </tedi-scroll-fade>
       </tedi-modal-content>
       <tedi-modal-footer>
-        <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
-        <button tedi-button (click)="ref.close()">Save</button>
+        <button tedi-button variant="secondary" (click)="ref.close()">Katkesta</button>
+        <button tedi-button (click)="ref.close()">Lisa</button>
       </tedi-modal-footer>
     </tedi-modal>
   `,
@@ -148,7 +304,6 @@ class StoryScrollableContentComponent {
 class StoryScrollableFadeContentComponent {
   readonly data = inject(MODAL_DATA) as StoryModalData;
   readonly ref = inject(ModalRef);
-  readonly fields = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 }
 
 @Component({
@@ -161,14 +316,10 @@ class StoryScrollableFadeContentComponent {
         <h1>{{ data.title }}</h1>
       </tedi-modal-header>
       <tedi-modal-content>
-        <div>
-          <label tedi-label for="select-1">Label</label>
-          <tedi-select inputId="select-1" state="default">
-            @for (option of data.options; track option.value) {
-              <tedi-select-option [value]="option.value" [label]="option.label" />
-            }
-          </tedi-select>
-        </div>
+        <tedi-form-field>
+          <label tedi-label for="field-1">Label</label>
+          <input tedi-text-field id="field-1" />
+        </tedi-form-field>
       </tedi-modal-content>
       <tedi-modal-footer style="justify-content: space-between;">
         <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
@@ -192,14 +343,10 @@ class StoryFooterLeftRightComponent {
         <h1>{{ data.title }}</h1>
       </tedi-modal-header>
       <tedi-modal-content>
-        <div>
-          <label tedi-label for="select-1">Label</label>
-          <tedi-select inputId="select-1" state="default">
-            @for (option of data.options; track option.value) {
-              <tedi-select-option [value]="option.value" [label]="option.label" />
-            }
-          </tedi-select>
-        </div>
+        <tedi-form-field>
+          <label tedi-label for="field-1">Label</label>
+          <input tedi-text-field id="field-1" />
+        </tedi-form-field>
       </tedi-modal-content>
       <tedi-modal-footer style="justify-content: space-between;">
         <button tedi-button variant="neutral" (click)="ref.close()">
@@ -229,14 +376,10 @@ class StoryFooterThreeButtonsComponent {
         <h1>{{ data.title }}</h1>
       </tedi-modal-header>
       <tedi-modal-content>
-        <div>
-          <label tedi-label for="select-1">Label</label>
-          <tedi-select inputId="select-1" state="default">
-            @for (option of data.options; track option.value) {
-              <tedi-select-option [value]="option.value" [label]="option.label" />
-            }
-          </tedi-select>
-        </div>
+        <tedi-form-field>
+          <label tedi-label for="field-1">Label</label>
+          <input tedi-text-field id="field-1" />
+        </tedi-form-field>
       </tedi-modal-content>
     </tedi-modal>
   `,
@@ -331,59 +474,96 @@ export default {
     }),
   ],
   parameters: {},
+  argTypes: {
+    size: {
+      table: { type: { summary: "'default' | 'small'" }, defaultValue: { summary: "'default'" }, category: "ModalConfig" },
+      description: "Modal size variant. Controls padding, heading size, and close button size.",
+    },
+    width: {
+      table: { type: { summary: "'xs' | 'sm' | 'md' | 'lg' | 'xl' | string" }, defaultValue: { summary: "'sm'" }, category: "ModalConfig" },
+      description: "Modal width — preset token or custom CSS value (e.g. `'800px'`, `'60%'`).",
+    },
+    maxWidth: {
+      table: { type: { summary: "string" }, defaultValue: { summary: "'95vw'" }, category: "ModalConfig" },
+      description: "Max-width cap (e.g. `'75%'`, `'60vw'`). Overrides the default 95vw limit.",
+    },
+    position: {
+      table: { type: { summary: "'center' | 'top' | 'left' | 'right'" }, defaultValue: { summary: "'center'" }, category: "ModalConfig" },
+      description: "Position of the modal on screen. `'left'` and `'right'` create side/drawer modals.",
+    },
+    scrollBehavior: {
+      table: { type: { summary: "'content' | 'page'" }, defaultValue: { summary: "'content'" }, category: "ModalConfig" },
+      description: "Scroll behavior when content overflows. `'content'` scrolls inside the modal, `'page'` scrolls the full overlay.",
+    },
+    fullscreen: {
+      table: { type: { summary: "boolean | 'sm' | 'md' | 'lg' | 'xl'" }, defaultValue: { summary: "false" }, category: "ModalConfig" },
+      description: "Fullscreen mode. `true` = always fullscreen. A breakpoint string (e.g. `'md'`) makes the modal fullscreen below that breakpoint.",
+    },
+    closeOnBackdropClick: {
+      table: { type: { summary: "boolean" }, defaultValue: { summary: "true" }, category: "ModalConfig" },
+      description: "Whether clicking the backdrop closes the modal.",
+    },
+    closeOnEscape: {
+      table: { type: { summary: "boolean" }, defaultValue: { summary: "true" }, category: "ModalConfig" },
+      description: "Whether pressing Escape closes the modal.",
+    },
+    showClose: {
+      table: { type: { summary: "boolean" }, defaultValue: { summary: "true" }, category: "ModalConfig" },
+      description: "Whether to show a close button in the header. Set via `[showClose]` on `<tedi-modal-header>`.",
+    },
+    data: {
+      table: { type: { summary: "unknown" }, category: "ModalConfig" },
+      description: "Data passed to the modal content component. Accessible via `inject(MODAL_DATA)`.",
+    },
+    ariaLabel: {
+      table: { type: { summary: "string" }, category: "ModalConfig" },
+      description: "ARIA label for the dialog element.",
+    },
+    ariaLabelledBy: {
+      table: { type: { summary: "string" }, category: "ModalConfig" },
+      description: "ID of the element that labels the dialog.",
+    },
+  },
 } as Meta<ModalComponent>;
 
 export const Default: StoryObj = {
+  args: {
+    size: "default",
+    width: "md",
+    maxWidth: "",
+    position: "center",
+    scrollBehavior: "content",
+    fullscreen: false,
+    closeOnBackdropClick: true,
+    closeOnEscape: true,
+    showClose: true,
+  },
+  argTypes: {
+    size: { control: "select", options: ["default", "small"] },
+    width: { control: "text" },
+    maxWidth: { control: "text" },
+    position: { control: "select", options: ["center", "top", "left", "right"] },
+    scrollBehavior: { control: "select", options: ["content", "page"] },
+    fullscreen: { control: "text", description: "Set `true` for always fullscreen or a breakpoint string (`sm`, `md`, `lg`, `xl`)." },
+    closeOnBackdropClick: { control: "boolean" },
+    closeOnEscape: { control: "boolean" },
+    showClose: { control: "boolean" },
+  },
   parameters: {
     docs: {
       source: {
         code: `
-// --- Opening the modal ---
 private modalService = inject(ModalService);
 
-// Center (default)
 this.modalService.open(MyModalContent, {
-  data: { title: 'Center modal' },
+  data: { title: 'Modal title' },
+  size: 'default',
   width: 'md',
-});
-
-// Top-aligned
-this.modalService.open(MyModalContent, {
-  data: { title: 'Top-aligned modal' },
-  width: 'md',
-  position: 'top',
-});
-
-// Side (right or left)
-this.modalService.open(MyModalContent, {
-  data: { title: 'Side modal' },
-  width: 'sm',
-  position: 'right', // or 'left'
-});
-
-// Custom max-width — overrides the default 95vw cap
-this.modalService.open(MyModalContent, {
-  data: { title: 'Custom max-width' },
-  position: 'left',
-  width: '800px',
-  maxWidth: '75%',
-});
-
-// No backdrop close
-this.modalService.open(MyModalContent, {
-  data: { title: 'No backdrop close' },
-  width: 'md',
-  closeOnBackdropClick: false,
-});
-
-// No close button — set showClose on <tedi-modal-header>
-// <tedi-modal-header [showClose]="false">
-
-// Mobile fullscreen
-this.modalService.open(MyModalContent, {
-  data: { title: 'Mobile fullscreen' },
-  width: 'md',
-  mobileFullscreen: true,
+  position: 'center',
+  scrollBehavior: 'content',
+  fullscreen: false,
+  closeOnBackdropClick: true,
+  closeOnEscape: true,
 });
 
 // --- Modal content component ---
@@ -391,9 +571,8 @@ this.modalService.open(MyModalContent, {
   imports: [ModalComponent, ModalHeaderComponent, ModalContentComponent, ModalFooterComponent, ButtonComponent],
   template: \`
     <tedi-modal>
-      <tedi-modal-header>
+      <tedi-modal-header [showClose]="data.showClose">
         <h1>{{ data.title }}</h1>
-        <p tedi-modal-description>Optional description</p>
       </tedi-modal-header>
       <tedi-modal-content>
         <!-- Your content here -->
@@ -419,119 +598,158 @@ class MyModalContent {
       imports: [ButtonComponent, StoryModalContentComponent],
     }),
   ],
-  render: () => {
+  render: (args) => {
     @Component({
       standalone: true,
-      selector: "story-service-demo",
+      selector: "story-default-demo",
       imports: [ButtonComponent],
       template: `
-        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
-          <button tedi-button (click)="openCenter()">Open center modal</button>
-          <button tedi-button (click)="openTop()">Open top-aligned modal</button>
-          <button tedi-button (click)="openRight()">Open side modal (right)</button>
-          <button tedi-button (click)="openLeft()">Open side modal (left)</button>
-          <button tedi-button (click)="openCustomMaxWidth()">Side modal with custom widths</button>
-          <button tedi-button (click)="openNoBackdropClose()">No backdrop close</button>
-          <button tedi-button (click)="openNoCloseButton()">No close button</button>
-          <button tedi-button (click)="openWithDescription()">With description</button>
-          <button tedi-button (click)="openMobileFullscreen()">Mobile fullscreen</button>
-        </div>
+        <button tedi-button variant="secondary" (click)="open()">Open modal</button>
       `,
     })
-    class ServiceDemoComponent {
+    class DefaultDemoComponent {
       private readonly modalService = inject(ModalService);
-      lastResult: string | null = null;
 
-      private readonly options = defaultOptions;
 
-      openCenter() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "Center modal", options: this.options },
-          width: "md",
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      @Input() size!: string;
+      @Input() width!: string;
+      @Input() maxWidth!: string;
+      @Input() position!: string;
+      @Input() scrollBehavior!: string;
+      @Input() fullscreen!: boolean | string;
+      @Input() closeOnBackdropClick!: boolean;
+      @Input() closeOnEscape!: boolean;
+      @Input() showClose!: boolean;
+
+      private parseFullscreen(): boolean | string {
+        if (this.fullscreen === "true" || this.fullscreen === true) return true;
+        if (this.fullscreen === "false" || this.fullscreen === false) return false;
+        return this.fullscreen;
       }
 
-      openTop() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "Top-aligned modal", options: this.options },
-          width: "md",
-          position: "top",
+      open() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Modal title", showClose: this.showClose },
+          size: this.size as "default" | "small",
+          width: this.width,
+          maxWidth: this.maxWidth || undefined,
+          position: this.position as "center" | "top" | "left" | "right",
+          scrollBehavior: this.scrollBehavior as "content" | "page",
+          fullscreen: this.parseFullscreen() as boolean | "sm" | "md" | "lg" | "xl",
+          closeOnBackdropClick: this.closeOnBackdropClick,
+          closeOnEscape: this.closeOnEscape,
         });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
-      }
-
-      openRight() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "Side modal (right)", options: this.options },
-          width: "sm",
-          position: "right",
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
-      }
-
-      openLeft() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "Side modal (left)", options: this.options },
-          width: "sm",
-          position: "left",
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
-      }
-
-      openCustomMaxWidth() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "Side modal (800px, max 75%)", options: this.options },
-          position: "left",
-          width: "800px",
-          maxWidth: "75%",
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
-      }
-
-      openNoBackdropClose() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "No backdrop close", options: this.options },
-          width: "md",
-          closeOnBackdropClick: false,
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
-      }
-
-      openNoCloseButton() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "No close button", showClose: false, options: this.options },
-          width: "md",
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
-      }
-
-      openMobileFullscreen() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: { title: "Mobile fullscreen", options: this.options },
-          width: "md",
-          mobileFullscreen: true,
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
-      }
-
-      openWithDescription() {
-        const ref = this.modalService.open<string>(StoryModalContentComponent, {
-          data: {
-            title: "With description",
-            description: "This modal has additional description text in the header.",
-            options: this.options,
-          },
-          width: "md",
-        });
-        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
       }
     }
 
     return {
-      template: "<story-service-demo />",
+      template: `<story-default-demo
+        [size]="size"
+        [width]="width"
+        [maxWidth]="maxWidth"
+        [position]="position"
+        [scrollBehavior]="scrollBehavior"
+        [fullscreen]="fullscreen"
+        [closeOnBackdropClick]="closeOnBackdropClick"
+        [closeOnEscape]="closeOnEscape"
+        [showClose]="showClose"
+      />`,
       moduleMetadata: {
-        imports: [ServiceDemoComponent],
+        imports: [DefaultDemoComponent],
+      },
+      props: args,
+    };
+  },
+};
+
+export const Position: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Center (default)
+this.modalService.open(MyModalContent, {
+  data: { title: 'Center modal' },
+  width: 'md',
+});
+
+// Top-aligned
+this.modalService.open(MyModalContent, {
+  data: { title: 'Top-aligned modal' },
+  width: 'md',
+  position: 'top',
+});
+
+// Side (right or left)
+this.modalService.open(MyModalContent, {
+  data: { title: 'Side modal' },
+  width: 'sm',
+  position: 'right', // or 'left'
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-position-demo",
+      imports: [ButtonComponent],
+      template: `
+        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+          <button tedi-button variant="secondary" (click)="openCenter()">Center</button>
+          <button tedi-button variant="secondary" (click)="openTop()">Top-aligned</button>
+          <button tedi-button variant="secondary" (click)="openRight()">Side (right)</button>
+          <button tedi-button variant="secondary" (click)="openLeft()">Side (left)</button>
+        </div>
+      `,
+    })
+    class PositionDemoComponent {
+      private readonly modalService = inject(ModalService);
+
+
+      openCenter() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Center modal" },
+          width: "md",
+        });
+      }
+
+      openTop() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Top-aligned modal" },
+          width: "md",
+          position: "top",
+        });
+      }
+
+      openRight() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Side modal (right)" },
+          width: "sm",
+          position: "right",
+        });
+      }
+
+      openLeft() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Side modal (left)" },
+          width: "sm",
+          position: "left",
+        });
+      }
+    }
+
+    return {
+      template: "<story-position-demo />",
+      moduleMetadata: {
+        imports: [PositionDemoComponent],
       },
     };
   },
@@ -572,18 +790,18 @@ this.modalService.open(MyModalContent, {
       imports: [ButtonComponent],
       template: `
         <div style="display: flex; gap: 16px;">
-          <button tedi-button (click)="openSmall()">Open small modal</button>
-          <button tedi-button (click)="openDefault()">Open default modal</button>
+          <button tedi-button variant="secondary" (click)="openSmall()">Open small modal</button>
+          <button tedi-button variant="secondary" (click)="openDefault()">Open default modal</button>
         </div>
       `,
     })
     class SizeDemoComponent {
       private readonly modalService = inject(ModalService);
-      private readonly options = defaultOptions;
+
 
       openSmall() {
         this.modalService.open(StoryModalContentComponent, {
-          data: { title: "Small modal", options: this.options },
+          data: { title: "Small modal" },
           size: "small",
           width: "sm",
         });
@@ -591,7 +809,7 @@ this.modalService.open(MyModalContent, {
 
       openDefault() {
         this.modalService.open(StoryModalContentComponent, {
-          data: { title: "Default modal", options: this.options },
+          data: { title: "Default modal" },
           size: "default",
           width: "sm",
         });
@@ -616,12 +834,6 @@ export const Width: StoryObj = {
 this.modalService.open(MyModalContent, {
   data: { title: 'Width: md' },
   width: 'md',
-});
-
-// Custom width — any CSS value (percentage, px, rem, etc.)
-this.modalService.open(MyModalContent, {
-  data: { title: 'Width: 80%' },
-  width: '80%',
 });`,
         language: "typescript",
         type: "code",
@@ -640,23 +852,21 @@ this.modalService.open(MyModalContent, {
       imports: [ButtonComponent],
       template: `
         <div style="display: flex; gap: 16px; flex-wrap: wrap;">
-          <button tedi-button (click)="openWidth('xs')">xs</button>
-          <button tedi-button (click)="openWidth('sm')">sm</button>
-          <button tedi-button (click)="openWidth('md')">md</button>
-          <button tedi-button (click)="openWidth('lg')">lg</button>
-          <button tedi-button (click)="openWidth('xl')">xl</button>
-          <button tedi-button (click)="openWidth('80%')">80%</button>
-          <button tedi-button (click)="openWidth('600px')">600px</button>
+          <button tedi-button variant="secondary" (click)="openWidth('xs')">xs</button>
+          <button tedi-button variant="secondary" (click)="openWidth('sm')">sm</button>
+          <button tedi-button variant="secondary" (click)="openWidth('md')">md</button>
+          <button tedi-button variant="secondary" (click)="openWidth('lg')">lg</button>
+          <button tedi-button variant="secondary" (click)="openWidth('xl')">xl</button>
         </div>
       `,
     })
     class WidthDemoComponent {
       private readonly modalService = inject(ModalService);
-      private readonly options = defaultOptions;
+
 
       openWidth(width: string) {
         this.modalService.open(StoryModalContentComponent, {
-          data: { title: `Width: ${width}`, options: this.options },
+          data: { title: `Width: ${width}` },
           width,
         });
       }
@@ -666,6 +876,172 @@ this.modalService.open(MyModalContent, {
       template: "<story-width-demo />",
       moduleMetadata: {
         imports: [WidthDemoComponent],
+      },
+    };
+  },
+};
+
+export const CustomWidth: StoryObj = {
+  name: "Custom width",
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Custom width with maxWidth cap — responsive via CSS
+this.modalService.open(MyModalContent, {
+  data: { title: 'Custom width modal' },
+  position: 'left',
+  width: '800px',
+  maxWidth: '75%',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  args: {
+    width: "800px",
+    maxWidth: "75%",
+    position: "left",
+  },
+  argTypes: {
+    width: {
+      control: "text",
+      description: "Custom CSS width value (e.g. '800px', '50vw', '60%').",
+    },
+    maxWidth: {
+      control: "text",
+      description: "Max-width cap (e.g. '75%', '60vw'). Overrides the default 95vw limit.",
+    },
+    position: {
+      control: "select",
+      options: ["center", "top", "left", "right"],
+      description: "Position of the modal.",
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: (args) => {
+    @Component({
+      standalone: true,
+      selector: "story-custom-width-demo",
+      imports: [ButtonComponent],
+      template: `
+        <button tedi-button variant="secondary" (click)="open()">Open modal</button>
+      `,
+    })
+    class CustomWidthDemoComponent {
+      private readonly modalService = inject(ModalService);
+
+
+      @Input() width!: string;
+      @Input() maxWidth!: string;
+      @Input() position!: "center" | "top" | "left" | "right";
+
+      open() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: `Width: ${this.width}, max: ${this.maxWidth}` },
+          position: this.position,
+          width: this.width,
+          maxWidth: this.maxWidth || undefined,
+        });
+      }
+    }
+
+    return {
+      template: "<story-custom-width-demo [width]=\"width\" [maxWidth]=\"maxWidth\" [position]=\"position\" />",
+      moduleMetadata: {
+        imports: [CustomWidthDemoComponent],
+      },
+      props: args,
+    };
+  },
+};
+
+export const Fullscreen: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Always fullscreen
+this.modalService.open(MyModalContent, {
+  data: { title: 'Fullscreen modal' },
+  width: 'md',
+  fullscreen: true,
+});
+
+// Fullscreen below 'md' breakpoint
+this.modalService.open(MyModalContent, {
+  data: { title: 'Fullscreen below md' },
+  width: 'md',
+  fullscreen: 'md',
+});
+
+// Fullscreen below 'sm' breakpoint (mobile only)
+this.modalService.open(MyModalContent, {
+  data: { title: 'Fullscreen on mobile' },
+  width: 'md',
+  fullscreen: 'sm',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-fullscreen-demo",
+      imports: [ButtonComponent],
+      template: `
+        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+          <button tedi-button variant="secondary" (click)="openAlways()">Always fullscreen</button>
+          <button tedi-button variant="secondary" (click)="openMd()">Fullscreen below md</button>
+          <button tedi-button variant="secondary" (click)="openSm()">Fullscreen on mobile</button>
+        </div>
+      `,
+    })
+    class FullscreenDemoComponent {
+      private readonly modalService = inject(ModalService);
+
+
+      openAlways() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Fullscreen modal" },
+          width: "md",
+          fullscreen: true,
+        });
+      }
+
+      openMd() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Fullscreen below md" },
+          width: "md",
+          fullscreen: "md",
+        });
+      }
+
+      openSm() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Fullscreen on mobile" },
+          width: "md",
+          fullscreen: "sm",
+        });
+      }
+    }
+
+    return {
+      template: "<story-fullscreen-demo />",
+      moduleMetadata: {
+        imports: [FullscreenDemoComponent],
       },
     };
   },
@@ -726,34 +1102,34 @@ this.modalService.open(MyModalContent, {
       imports: [ButtonComponent],
       template: `
         <div style="display: flex; gap: 16px; flex-wrap: wrap;">
-          <button tedi-button (click)="openScrollbar()">Content scrollbar</button>
-          <button tedi-button (click)="openFade()">Content fade</button>
-          <button tedi-button (click)="openPageScroll()">Page scroll</button>
+          <button tedi-button variant="secondary" (click)="openScrollbar()">Content scrollbar</button>
+          <button tedi-button variant="secondary" (click)="openFade()">Content fade</button>
+          <button tedi-button variant="secondary" (click)="openPageScroll()">Page scroll</button>
         </div>
       `,
     })
     class ScrollableDemoComponent {
       private readonly modalService = inject(ModalService);
-      private readonly options = defaultOptions;
+
 
       openScrollbar() {
         this.modalService.open(StoryScrollableContentComponent, {
-          data: { title: "Title", options: this.options },
-          width: "sm",
+          data: { title: "Uus toiming" },
+          width: "md",
         });
       }
 
       openFade() {
         this.modalService.open(StoryScrollableFadeContentComponent, {
-          data: { title: "Title", options: this.options },
-          width: "sm",
+          data: { title: "Uus toiming" },
+          width: "md",
         });
       }
 
       openPageScroll() {
         this.modalService.open(StoryScrollableContentComponent, {
-          data: { title: "Title", options: this.options },
-          width: "sm",
+          data: { title: "Uus toiming" },
+          width: "md",
           scrollBehavior: "page",
         });
       }
@@ -763,6 +1139,168 @@ this.modalService.open(MyModalContent, {
       template: "<story-scrollable-demo />",
       moduleMetadata: {
         imports: [ScrollableDemoComponent],
+      },
+    };
+  },
+};
+
+export const WithDescription: StoryObj = {
+  name: "With header description",
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Add a <p tedi-modal-description> inside <tedi-modal-header>:
+// <tedi-modal-header>
+//   <h1>Title</h1>
+//   <p tedi-modal-description>Description text</p>
+// </tedi-modal-header>
+this.modalService.open(MyModalContent, {
+  data: { title: 'With description', description: 'Additional description in the header.' },
+  width: 'md',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-description-demo",
+      imports: [ButtonComponent],
+      template: `
+        <button tedi-button variant="secondary" (click)="open()">With description</button>
+      `,
+    })
+    class DescriptionDemoComponent {
+      private readonly modalService = inject(ModalService);
+
+
+      open() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: {
+            title: "With description",
+            description: "This modal has additional description text in the header.",
+          },
+          width: "md",
+        });
+      }
+    }
+
+    return {
+      template: "<story-description-demo />",
+      moduleMetadata: {
+        imports: [DescriptionDemoComponent],
+      },
+    };
+  },
+};
+
+export const NoBackdropClose: StoryObj = {
+  name: "No backdrop close",
+  parameters: {
+    docs: {
+      source: {
+        code: `
+this.modalService.open(MyModalContent, {
+  data: { title: 'No backdrop close' },
+  width: 'md',
+  closeOnBackdropClick: false,
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-no-backdrop-demo",
+      imports: [ButtonComponent],
+      template: `
+        <button tedi-button variant="secondary" (click)="open()">No backdrop close</button>
+      `,
+    })
+    class NoBackdropDemoComponent {
+      private readonly modalService = inject(ModalService);
+
+
+      open() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "No backdrop close" },
+          width: "md",
+          closeOnBackdropClick: false,
+        });
+      }
+    }
+
+    return {
+      template: "<story-no-backdrop-demo />",
+      moduleMetadata: {
+        imports: [NoBackdropDemoComponent],
+      },
+    };
+  },
+};
+
+export const NoCloseButton: StoryObj = {
+  name: "No close button",
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Set showClose on the modal content component's <tedi-modal-header>:
+// <tedi-modal-header [showClose]="false">
+this.modalService.open(MyModalContent, {
+  data: { title: 'No close button', showClose: false },
+  width: 'md',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-no-close-demo",
+      imports: [ButtonComponent],
+      template: `
+        <button tedi-button variant="secondary" (click)="open()">No close button</button>
+      `,
+    })
+    class NoCloseDemoComponent {
+      private readonly modalService = inject(ModalService);
+
+
+      open() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "No close button", showClose: false },
+          width: "md",
+        });
+      }
+    }
+
+    return {
+      template: "<story-no-close-demo />",
+      moduleMetadata: {
+        imports: [NoCloseDemoComponent],
       },
     };
   },
@@ -826,17 +1364,17 @@ this.modalService.open(MyModalContent, {
       imports: [ButtonComponent],
       template: `
         <div style="display: flex; gap: 16px; flex-wrap: wrap;">
-          <button tedi-button (click)="openDefault()">Open modal</button>
-          <button tedi-button (click)="openLeftRight()">Left right buttons</button>
-          <button tedi-button (click)="openThreeButtons()">Three buttons</button>
-          <button tedi-button (click)="openNoFooter()">No footer</button>
+          <button tedi-button variant="secondary" (click)="openDefault()">Open modal</button>
+          <button tedi-button variant="secondary" (click)="openLeftRight()">Left right buttons</button>
+          <button tedi-button variant="secondary" (click)="openThreeButtons()">Three buttons</button>
+          <button tedi-button variant="secondary" (click)="openNoFooter()">No footer</button>
         </div>
       `,
     })
     class FooterDemoComponent {
       private readonly modalService = inject(ModalService);
-      private readonly options = defaultOptions;
-      private readonly data: StoryModalData = { title: "Title", options: this.options };
+
+      private readonly data: StoryModalData = { title: "Title" };
 
       openDefault() {
         this.modalService.open(StoryModalContentComponent, {
@@ -902,31 +1440,22 @@ export const TemplateBased: StoryObj<ModalComponent> = {
     props: {
       ...args,
       open: false,
-      options: defaultOptions,
     },
     template: `
-      <button tedi-button (click)="open = true">Open modal</button>
+      <button tedi-button variant="secondary" (click)="open = true">Open modal</button>
       <tedi-modal [(open)]="open">
         <tedi-modal-header>
           <h1>Title</h1>
         </tedi-modal-header>
         <tedi-modal-content>
-          <div>
-            <label tedi-label for="select-1">Label</label>
-            <tedi-select inputId="select-1" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-          <div>
-            <label tedi-label for="select-2">Label</label>
-            <tedi-select inputId="select-2" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
+          <tedi-form-field>
+            <label tedi-label for="tpl-field-1">Label</label>
+            <input tedi-text-field id="tpl-field-1" />
+          </tedi-form-field>
+          <tedi-form-field>
+            <label tedi-label for="tpl-field-2">Label</label>
+            <input tedi-text-field id="tpl-field-2" />
+          </tedi-form-field>
         </tedi-modal-content>
         <tedi-modal-footer>
           <button tedi-button variant="secondary" (click)="open = false">Cancel</button>

--- a/tedi/components/overlay/modal/modal.stories.ts
+++ b/tedi/components/overlay/modal/modal.stories.ts
@@ -361,6 +361,14 @@ this.modalService.open(MyModalContent, {
   position: 'right', // or 'left'
 });
 
+// Custom max-width — overrides the default 95vw cap
+this.modalService.open(MyModalContent, {
+  data: { title: 'Custom max-width' },
+  position: 'left',
+  width: '800px',
+  maxWidth: '75%',
+});
+
 // No backdrop close
 this.modalService.open(MyModalContent, {
   data: { title: 'No backdrop close' },
@@ -422,6 +430,7 @@ class MyModalContent {
           <button tedi-button (click)="openTop()">Open top-aligned modal</button>
           <button tedi-button (click)="openRight()">Open side modal (right)</button>
           <button tedi-button (click)="openLeft()">Open side modal (left)</button>
+          <button tedi-button (click)="openCustomMaxWidth()">Side modal with custom widths</button>
           <button tedi-button (click)="openNoBackdropClose()">No backdrop close</button>
           <button tedi-button (click)="openNoCloseButton()">No close button</button>
           <button tedi-button (click)="openWithDescription()">With description</button>
@@ -466,6 +475,16 @@ class MyModalContent {
           data: { title: "Side modal (left)", options: this.options },
           width: "sm",
           position: "left",
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openCustomMaxWidth() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "Side modal (800px, max 75%)", options: this.options },
+          position: "left",
+          width: "800px",
+          maxWidth: "75%",
         });
         ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
       }

--- a/tedi/components/overlay/modal/modal.stories.ts
+++ b/tedi/components/overlay/modal/modal.stories.ts
@@ -1,12 +1,250 @@
 import { type Meta, type StoryObj, moduleMetadata } from "@storybook/angular";
+import { Component, inject } from "@angular/core";
 import { ModalComponent } from "./modal.component";
 import { ModalHeaderComponent } from "./modal-header/modal-header.component";
 import { ModalContentComponent } from "./modal-content/modal-content.component";
 import { ModalFooterComponent } from "./modal-footer/modal-footer.component";
+import { ModalService } from "./modal.service";
+import { ModalRef } from "./modal-ref";
+import { MODAL_DATA } from "./modal.types";
 import { ButtonComponent } from "../../buttons/button/button.component";
 import { LabelComponent } from "../../form/label/label.component";
 import { SelectComponent, SelectOptionComponent } from "@tedi-design-system/angular/community";
 import { IconComponent } from "../../base/icon/icon.component";
+import { ScrollFadeComponent } from "../../helpers/scroll-fade/scroll-fade.component";
+
+const defaultOptions = [
+  { value: "1", label: "Option 1" },
+  { value: "2", label: "Option 2" },
+  { value: "3", label: "Option 3" },
+  { value: "4", label: "Option 4" },
+  { value: "5", label: "Option 5" },
+];
+
+interface StoryModalData {
+  title: string;
+  description?: string;
+  showClose?: boolean;
+  options: { value: string; label: string }[];
+}
+
+const sharedModalImports = [
+  ModalComponent,
+  ModalHeaderComponent,
+  ModalContentComponent,
+  ModalFooterComponent,
+  ButtonComponent,
+  LabelComponent,
+  SelectComponent,
+  SelectOptionComponent,
+];
+
+@Component({
+  standalone: true,
+  selector: "story-modal-content",
+  imports: sharedModalImports,
+  template: `
+    <tedi-modal>
+      <tedi-modal-header [showClose]="data.showClose ?? true">
+        <h1>{{ data.title }}</h1>
+        @if (data.description) {
+          <p tedi-modal-description>{{ data.description }}</p>
+        }
+      </tedi-modal-header>
+      <tedi-modal-content>
+        <div>
+          <label tedi-label for="select-1">Label</label>
+          <tedi-select inputId="select-1" state="default">
+            @for (option of data.options; track option.value) {
+              <tedi-select-option [value]="option.value" [label]="option.label" />
+            }
+          </tedi-select>
+        </div>
+        <div>
+          <label tedi-label for="select-2">Label</label>
+          <tedi-select inputId="select-2" state="default">
+            @for (option of data.options; track option.value) {
+              <tedi-select-option [value]="option.value" [label]="option.label" />
+            }
+          </tedi-select>
+        </div>
+      </tedi-modal-content>
+      <tedi-modal-footer>
+        <button tedi-button variant="secondary" (click)="ref.close('cancel')">Cancel</button>
+        <button tedi-button (click)="ref.close('confirm')">Continue</button>
+      </tedi-modal-footer>
+    </tedi-modal>
+  `,
+})
+class StoryModalContentComponent {
+  readonly data = inject(MODAL_DATA) as StoryModalData;
+  readonly ref = inject(ModalRef);
+}
+
+@Component({
+  standalone: true,
+  selector: "story-scrollable-content",
+  imports: sharedModalImports,
+  template: `
+    <tedi-modal>
+      <tedi-modal-header>
+        <h1>{{ data.title }}</h1>
+      </tedi-modal-header>
+      <tedi-modal-content>
+        @for (i of fields; track i) {
+          <div>
+            <label tedi-label [for]="'select-' + i">Label</label>
+            <tedi-select [inputId]="'select-' + i" state="default">
+              @for (option of data.options; track option.value) {
+                <tedi-select-option [value]="option.value" [label]="option.label" />
+              }
+            </tedi-select>
+          </div>
+        }
+      </tedi-modal-content>
+      <tedi-modal-footer>
+        <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
+        <button tedi-button (click)="ref.close()">Save</button>
+      </tedi-modal-footer>
+    </tedi-modal>
+  `,
+})
+class StoryScrollableContentComponent {
+  readonly data = inject(MODAL_DATA) as StoryModalData;
+  readonly ref = inject(ModalRef);
+  readonly fields = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+}
+
+@Component({
+  standalone: true,
+  selector: "story-scrollable-fade-content",
+  imports: [...sharedModalImports, ScrollFadeComponent],
+  template: `
+    <tedi-modal>
+      <tedi-modal-header>
+        <h1>{{ data.title }}</h1>
+      </tedi-modal-header>
+      <tedi-modal-content>
+        <tedi-scroll-fade fadePosition="both" fadeSize="10">
+          @for (i of fields; track i) {
+            <div style="padding: 8px 0;">
+              <label tedi-label [for]="'select-' + i">Label</label>
+              <tedi-select [inputId]="'select-' + i" state="default">
+                @for (option of data.options; track option.value) {
+                  <tedi-select-option [value]="option.value" [label]="option.label" />
+                }
+              </tedi-select>
+            </div>
+          }
+        </tedi-scroll-fade>
+      </tedi-modal-content>
+      <tedi-modal-footer>
+        <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
+        <button tedi-button (click)="ref.close()">Save</button>
+      </tedi-modal-footer>
+    </tedi-modal>
+  `,
+})
+class StoryScrollableFadeContentComponent {
+  readonly data = inject(MODAL_DATA) as StoryModalData;
+  readonly ref = inject(ModalRef);
+  readonly fields = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+}
+
+@Component({
+  standalone: true,
+  selector: "story-footer-left-right",
+  imports: sharedModalImports,
+  template: `
+    <tedi-modal>
+      <tedi-modal-header>
+        <h1>{{ data.title }}</h1>
+      </tedi-modal-header>
+      <tedi-modal-content>
+        <div>
+          <label tedi-label for="select-1">Label</label>
+          <tedi-select inputId="select-1" state="default">
+            @for (option of data.options; track option.value) {
+              <tedi-select-option [value]="option.value" [label]="option.label" />
+            }
+          </tedi-select>
+        </div>
+      </tedi-modal-content>
+      <tedi-modal-footer style="justify-content: space-between;">
+        <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
+        <button tedi-button (click)="ref.close()">Continue</button>
+      </tedi-modal-footer>
+    </tedi-modal>
+  `,
+})
+class StoryFooterLeftRightComponent {
+  readonly data = inject(MODAL_DATA) as StoryModalData;
+  readonly ref = inject(ModalRef);
+}
+
+@Component({
+  standalone: true,
+  selector: "story-footer-three-buttons",
+  imports: [...sharedModalImports, IconComponent],
+  template: `
+    <tedi-modal>
+      <tedi-modal-header>
+        <h1>{{ data.title }}</h1>
+      </tedi-modal-header>
+      <tedi-modal-content>
+        <div>
+          <label tedi-label for="select-1">Label</label>
+          <tedi-select inputId="select-1" state="default">
+            @for (option of data.options; track option.value) {
+              <tedi-select-option [value]="option.value" [label]="option.label" />
+            }
+          </tedi-select>
+        </div>
+      </tedi-modal-content>
+      <tedi-modal-footer style="justify-content: space-between;">
+        <button tedi-button variant="neutral" (click)="ref.close()">
+          <tedi-icon name="arrow_back" />
+          Back
+        </button>
+        <div class="flex gap-3">
+          <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
+          <button tedi-button (click)="ref.close()">Continue</button>
+        </div>
+      </tedi-modal-footer>
+    </tedi-modal>
+  `,
+})
+class StoryFooterThreeButtonsComponent {
+  readonly data = inject(MODAL_DATA) as StoryModalData;
+  readonly ref = inject(ModalRef);
+}
+
+@Component({
+  standalone: true,
+  selector: "story-no-footer",
+  imports: sharedModalImports,
+  template: `
+    <tedi-modal>
+      <tedi-modal-header>
+        <h1>{{ data.title }}</h1>
+      </tedi-modal-header>
+      <tedi-modal-content>
+        <div>
+          <label tedi-label for="select-1">Label</label>
+          <tedi-select inputId="select-1" state="default">
+            @for (option of data.options; track option.value) {
+              <tedi-select-option [value]="option.value" [label]="option.label" />
+            }
+          </tedi-select>
+        </div>
+      </tedi-modal-content>
+    </tedi-modal>
+  `,
+})
+class StoryNoFooterComponent {
+  readonly data = inject(MODAL_DATA) as StoryModalData;
+  readonly ref = inject(ModalRef);
+}
 
 /**
  * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.23.38?node-id=4626-89579&m=dev" target="_blank">Figma ↗</a><br>
@@ -14,22 +252,71 @@ import { IconComponent } from "../../base/icon/icon.component";
  *
  * ---
  *
- * The modal can be opened or closed using the `open` input (set it to `true` or `false`).
- * You can also control it programmatically using `viewChild`:
+ * ## Service-based modal (ModalService)
+ *
+ * Open modals programmatically via `ModalService.open()`. This uses Angular CDK Dialog
+ * under the hood and handles focus trapping, scroll blocking, backdrop, and keyboard
+ * events automatically.
  *
  * ```ts
- * modal = viewChild(ModalComponent);
+ * private modalService = inject(ModalService);
  *
- * toggleModal() {
- *   this.modal.open.update(prev => !prev);
+ * openModal() {
+ *   const ref = this.modalService.open(MyContentComponent, {
+ *     data: { title: 'Hello' },
+ *     width: 'md',
+ *     position: 'center',
+ *   });
+ *
+ *   ref.closed.subscribe(result => console.log(result));
  * }
  * ```
  *
- * The modal layout is composed of the following subcomponents:
+ * The content component wraps everything in `<tedi-modal>` and injects `MODAL_DATA` / `ModalRef`:
  *
- * - ModalHeaderComponent
- * - ModalContentComponent
- * - ModalFooterComponent
+ * ```ts
+ * @Component({
+ *   imports: [ModalComponent, ModalHeaderComponent, ModalContentComponent, ModalFooterComponent, ButtonComponent],
+ *   template: `
+ *     <tedi-modal>
+ *       <tedi-modal-header>
+ *         <h1>{{ data.title }}</h1>
+ *       </tedi-modal-header>
+ *       <tedi-modal-content>
+ *         <!-- Content -->
+ *       </tedi-modal-content>
+ *       <tedi-modal-footer>
+ *         <button tedi-button (click)="ref.close()">Close</button>
+ *       </tedi-modal-footer>
+ *     </tedi-modal>
+ *   `,
+ * })
+ * class MyContentComponent {
+ *   data = inject(MODAL_DATA);
+ *   ref = inject(ModalRef);
+ * }
+ * ```
+ *
+ * ## Template-based modal (deprecated)
+ *
+ * The `<tedi-modal>` component with `[(open)]` binding is deprecated.
+ * Migrate to `ModalService.open()` for new code.
+ *
+ * ```html
+ * <button tedi-button (click)="open = true">Open modal</button>
+ * <tedi-modal [(open)]="open" size="default" width="sm" position="center">
+ *   <tedi-modal-header>
+ *     <h1>Title</h1>
+ *   </tedi-modal-header>
+ *   <tedi-modal-content>
+ *     <!-- Content -->
+ *   </tedi-modal-content>
+ *   <tedi-modal-footer>
+ *     <button tedi-button variant="secondary" (click)="open = false">Cancel</button>
+ *     <button tedi-button (click)="open = false">Continue</button>
+ *   </tedi-modal-footer>
+ * </tedi-modal>
+ * ```
  */
 
 export default {
@@ -38,122 +325,570 @@ export default {
   decorators: [
     moduleMetadata({
       imports: [
-        ModalComponent,
-        ModalHeaderComponent,
-        ModalContentComponent,
-        ModalFooterComponent,
-        ButtonComponent,
-        LabelComponent,
-        SelectComponent,
-        SelectOptionComponent,
+        ...sharedModalImports,
         IconComponent,
       ],
     }),
   ],
-  argTypes: {
-    open: {
-      control: "boolean",
-      description: "Is modal open?",
-      table: {
-        category: "modal inputs",
-        type: {
-          summary: "boolean",
-        },
-        defaultValue: {
-          summary: "false",
-        },
-      },
-    },
-    size: {
-      control: "radio",
-      options: ["default", "small"],
-      description: "Modal size",
-      table: {
-        category: "modal inputs",
-        type: {
-          summary: "ModalSize",
-          detail: "default \nsmall",
-        },
-        defaultValue: {
-          summary: "default",
-        },
-      },
-    },
-    width: {
-      control: "radio",
-      options: ["xs", "sm", "md", "lg", "xl"],
-      description: "Modal width",
-      table: {
-        category: "modal inputs",
-        type: {
-          summary: "ModalWidth",
-          detail: "xs \nsm \nmd \nlg \nxl",
-        },
-        defaultValue: {
-          summary: "sm",
-        },
-      },
-    },
-    position: {
-      control: "radio",
-      options: ["center", "left", "right"],
-      description: "Position of the modal",
-      table: {
-        category: "modal inputs",
-        type: {
-          summary: "ModalPosition",
-          detail: "center \nleft \nright",
-        },
-        defaultValue: {
-          summary: "center",
-        },
-      },
-    },
-    showClose: {
-      control: "boolean",
-      description: "Should show closing button?",
-      table: {
-        category: "modal header inputs",
-        type: {
-          summary: "boolean",
-        },
-        defaultValue: {
-          summary: "true",
-        },
+  parameters: {},
+} as Meta<ModalComponent>;
+
+export const Default: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// --- Opening the modal ---
+private modalService = inject(ModalService);
+
+// Center (default)
+this.modalService.open(MyModalContent, {
+  data: { title: 'Center modal' },
+  width: 'md',
+});
+
+// Top-aligned
+this.modalService.open(MyModalContent, {
+  data: { title: 'Top-aligned modal' },
+  width: 'md',
+  position: 'top',
+});
+
+// Side (right or left)
+this.modalService.open(MyModalContent, {
+  data: { title: 'Side modal' },
+  width: 'sm',
+  position: 'right', // or 'left'
+});
+
+// No backdrop close
+this.modalService.open(MyModalContent, {
+  data: { title: 'No backdrop close' },
+  width: 'md',
+  closeOnBackdropClick: false,
+});
+
+// No close button — set showClose on <tedi-modal-header>
+// <tedi-modal-header [showClose]="false">
+
+// Mobile fullscreen
+this.modalService.open(MyModalContent, {
+  data: { title: 'Mobile fullscreen' },
+  width: 'md',
+  mobileFullscreen: true,
+});
+
+// --- Modal content component ---
+@Component({
+  imports: [ModalComponent, ModalHeaderComponent, ModalContentComponent, ModalFooterComponent, ButtonComponent],
+  template: \`
+    <tedi-modal>
+      <tedi-modal-header>
+        <h1>{{ data.title }}</h1>
+        <p tedi-modal-description>Optional description</p>
+      </tedi-modal-header>
+      <tedi-modal-content>
+        <!-- Your content here -->
+      </tedi-modal-content>
+      <tedi-modal-footer>
+        <button tedi-button variant="secondary" (click)="ref.close('cancel')">Cancel</button>
+        <button tedi-button (click)="ref.close('confirm')">Continue</button>
+      </tedi-modal-footer>
+    </tedi-modal>
+  \`,
+})
+class MyModalContent {
+  data = inject(MODAL_DATA);
+  ref = inject(ModalRef);
+}`,
+        language: "typescript",
+        type: "code",
       },
     },
   },
-} as Meta<ModalComponent>;
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-service-demo",
+      imports: [ButtonComponent],
+      template: `
+        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+          <button tedi-button (click)="openCenter()">Open center modal</button>
+          <button tedi-button (click)="openTop()">Open top-aligned modal</button>
+          <button tedi-button (click)="openRight()">Open side modal (right)</button>
+          <button tedi-button (click)="openLeft()">Open side modal (left)</button>
+          <button tedi-button (click)="openNoBackdropClose()">No backdrop close</button>
+          <button tedi-button (click)="openNoCloseButton()">No close button</button>
+          <button tedi-button (click)="openWithDescription()">With description</button>
+          <button tedi-button (click)="openMobileFullscreen()">Mobile fullscreen</button>
+        </div>
+      `,
+    })
+    class ServiceDemoComponent {
+      private readonly modalService = inject(ModalService);
+      lastResult: string | null = null;
 
-type DefaultStory = StoryObj<
-  ModalComponent & {
-    showClose: boolean;
-  }
->;
+      private readonly options = defaultOptions;
 
-export const Default: DefaultStory = {
-  args: {
-    open: false,
-    size: "default",
-    width: "sm",
-    position: "center",
-    showClose: true,
+      openCenter() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "Center modal", options: this.options },
+          width: "md",
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openTop() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "Top-aligned modal", options: this.options },
+          width: "md",
+          position: "top",
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openRight() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "Side modal (right)", options: this.options },
+          width: "sm",
+          position: "right",
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openLeft() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "Side modal (left)", options: this.options },
+          width: "sm",
+          position: "left",
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openNoBackdropClose() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "No backdrop close", options: this.options },
+          width: "md",
+          closeOnBackdropClick: false,
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openNoCloseButton() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "No close button", showClose: false, options: this.options },
+          width: "md",
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openMobileFullscreen() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: { title: "Mobile fullscreen", options: this.options },
+          width: "md",
+          mobileFullscreen: true,
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+
+      openWithDescription() {
+        const ref = this.modalService.open<string>(StoryModalContentComponent, {
+          data: {
+            title: "With description",
+            description: "This modal has additional description text in the header.",
+            options: this.options,
+          },
+          width: "md",
+        });
+        ref.closed.subscribe((r) => this.lastResult = r ?? "dismissed");
+      }
+    }
+
+    return {
+      template: "<story-service-demo />",
+      moduleMetadata: {
+        imports: [ServiceDemoComponent],
+      },
+    };
+  },
+};
+
+export const Size: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Small size — compact padding, smaller heading and close button
+this.modalService.open(MyModalContent, {
+  data: { title: 'Small modal' },
+  size: 'small',
+  width: 'sm',
+});
+
+// Default size — standard padding and heading
+this.modalService.open(MyModalContent, {
+  data: { title: 'Default modal' },
+  size: 'default', // default, can be omitted
+  width: 'sm',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-size-demo",
+      imports: [ButtonComponent],
+      template: `
+        <div style="display: flex; gap: 16px;">
+          <button tedi-button (click)="openSmall()">Open small modal</button>
+          <button tedi-button (click)="openDefault()">Open default modal</button>
+        </div>
+      `,
+    })
+    class SizeDemoComponent {
+      private readonly modalService = inject(ModalService);
+      private readonly options = defaultOptions;
+
+      openSmall() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Small modal", options: this.options },
+          size: "small",
+          width: "sm",
+        });
+      }
+
+      openDefault() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: "Default modal", options: this.options },
+          size: "default",
+          width: "sm",
+        });
+      }
+    }
+
+    return {
+      template: "<story-size-demo />",
+      moduleMetadata: {
+        imports: [SizeDemoComponent],
+      },
+    };
+  },
+};
+
+export const Width: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Preset widths: 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+this.modalService.open(MyModalContent, {
+  data: { title: 'Width: md' },
+  width: 'md',
+});
+
+// Custom width — any CSS value (percentage, px, rem, etc.)
+this.modalService.open(MyModalContent, {
+  data: { title: 'Width: 80%' },
+  width: '80%',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryModalContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-width-demo",
+      imports: [ButtonComponent],
+      template: `
+        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+          <button tedi-button (click)="openWidth('xs')">xs</button>
+          <button tedi-button (click)="openWidth('sm')">sm</button>
+          <button tedi-button (click)="openWidth('md')">md</button>
+          <button tedi-button (click)="openWidth('lg')">lg</button>
+          <button tedi-button (click)="openWidth('xl')">xl</button>
+          <button tedi-button (click)="openWidth('80%')">80%</button>
+          <button tedi-button (click)="openWidth('600px')">600px</button>
+        </div>
+      `,
+    })
+    class WidthDemoComponent {
+      private readonly modalService = inject(ModalService);
+      private readonly options = defaultOptions;
+
+      openWidth(width: string) {
+        this.modalService.open(StoryModalContentComponent, {
+          data: { title: `Width: ${width}`, options: this.options },
+          width,
+        });
+      }
+    }
+
+    return {
+      template: "<story-width-demo />",
+      moduleMetadata: {
+        imports: [WidthDemoComponent],
+      },
+    };
+  },
+};
+
+export const ScrollableContent: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// --- Content scrollbar (default) ---
+this.modalService.open(MyModalContent, {
+  data: { title: 'Scrollable modal' },
+  width: 'sm',
+});
+
+// --- Content fade ---
+// Wrap content in <tedi-scroll-fade> inside the content component.
+//
+// @Component({
+//   imports: [..., ScrollFadeComponent],
+//   template: \`
+//     <tedi-modal>
+//       <tedi-modal-content>
+//         <tedi-scroll-fade fadePosition="both" fadeSize="10">
+//           <!-- scrollable content here -->
+//         </tedi-scroll-fade>
+//       </tedi-modal-content>
+//     </tedi-modal>
+//   \`,
+// })
+this.modalService.open(MyFadeContent, {
+  data: { title: 'Fade modal' },
+  width: 'sm',
+});
+
+// --- Page scroll ---
+// The whole page scrolls instead of modal content.
+this.modalService.open(MyModalContent, {
+  data: { title: 'Page scroll modal' },
+  width: 'sm',
+  scrollBehavior: 'page',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [ButtonComponent, StoryScrollableContentComponent, StoryScrollableFadeContentComponent],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-scrollable-demo",
+      imports: [ButtonComponent],
+      template: `
+        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+          <button tedi-button (click)="openScrollbar()">Content scrollbar</button>
+          <button tedi-button (click)="openFade()">Content fade</button>
+          <button tedi-button (click)="openPageScroll()">Page scroll</button>
+        </div>
+      `,
+    })
+    class ScrollableDemoComponent {
+      private readonly modalService = inject(ModalService);
+      private readonly options = defaultOptions;
+
+      openScrollbar() {
+        this.modalService.open(StoryScrollableContentComponent, {
+          data: { title: "Title", options: this.options },
+          width: "sm",
+        });
+      }
+
+      openFade() {
+        this.modalService.open(StoryScrollableFadeContentComponent, {
+          data: { title: "Title", options: this.options },
+          width: "sm",
+        });
+      }
+
+      openPageScroll() {
+        this.modalService.open(StoryScrollableContentComponent, {
+          data: { title: "Title", options: this.options },
+          width: "sm",
+          scrollBehavior: "page",
+        });
+      }
+    }
+
+    return {
+      template: "<story-scrollable-demo />",
+      moduleMetadata: {
+        imports: [ScrollableDemoComponent],
+      },
+    };
+  },
+};
+
+export const FooterVariants: StoryObj = {
+  parameters: {
+    docs: {
+      source: {
+        code: `
+// Default footer — buttons aligned to the right
+// <tedi-modal-footer>
+//   <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
+//   <button tedi-button (click)="ref.close()">Continue</button>
+// </tedi-modal-footer>
+
+// Left-right footer — space-between alignment
+// <tedi-modal-footer style="justify-content: space-between;">
+//   <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
+//   <button tedi-button (click)="ref.close()">Continue</button>
+// </tedi-modal-footer>
+
+// Three buttons — back button on the left, cancel + continue on the right
+// <tedi-modal-footer style="justify-content: space-between;">
+//   <button tedi-button variant="neutral" (click)="ref.close()">
+//     <tedi-icon name="arrow_back" />
+//     Back
+//   </button>
+//   <div class="flex gap-3">
+//     <button tedi-button variant="secondary" (click)="ref.close()">Cancel</button>
+//     <button tedi-button (click)="ref.close()">Continue</button>
+//   </div>
+// </tedi-modal-footer>
+
+// No footer — simply omit <tedi-modal-footer>
+
+this.modalService.open(MyModalContent, {
+  data: { title: 'Title' },
+  size: 'small',
+});`,
+        language: "typescript",
+        type: "code",
+      },
+    },
+  },
+  decorators: [
+    moduleMetadata({
+      imports: [
+        ButtonComponent,
+        StoryModalContentComponent,
+        StoryFooterLeftRightComponent,
+        StoryFooterThreeButtonsComponent,
+        StoryNoFooterComponent,
+      ],
+    }),
+  ],
+  render: () => {
+    @Component({
+      standalone: true,
+      selector: "story-footer-demo",
+      imports: [ButtonComponent],
+      template: `
+        <div style="display: flex; gap: 16px; flex-wrap: wrap;">
+          <button tedi-button (click)="openDefault()">Open modal</button>
+          <button tedi-button (click)="openLeftRight()">Left right buttons</button>
+          <button tedi-button (click)="openThreeButtons()">Three buttons</button>
+          <button tedi-button (click)="openNoFooter()">No footer</button>
+        </div>
+      `,
+    })
+    class FooterDemoComponent {
+      private readonly modalService = inject(ModalService);
+      private readonly options = defaultOptions;
+      private readonly data: StoryModalData = { title: "Title", options: this.options };
+
+      openDefault() {
+        this.modalService.open(StoryModalContentComponent, {
+          data: this.data,
+          size: "small",
+        });
+      }
+
+      openLeftRight() {
+        this.modalService.open(StoryFooterLeftRightComponent, {
+          data: this.data,
+        });
+      }
+
+      openThreeButtons() {
+        this.modalService.open(StoryFooterThreeButtonsComponent, {
+          data: this.data,
+        });
+      }
+
+      openNoFooter() {
+        this.modalService.open(StoryNoFooterComponent, {
+          data: this.data,
+        });
+      }
+    }
+
+    return {
+      template: "<story-footer-demo />",
+      moduleMetadata: {
+        imports: [FooterDemoComponent],
+      },
+    };
+  },
+};
+
+export const TemplateBased: StoryObj<ModalComponent> = {
+  name: "Template-based (deprecated)",
+  parameters: {
+    docs: {
+      source: {
+        code: `
+<!-- Template-based modal (deprecated — use ModalService instead) -->
+<button tedi-button (click)="open = true">Open modal</button>
+<tedi-modal [(open)]="open" size="default" width="sm" position="center">
+  <tedi-modal-header>
+    <h1>Title</h1>
+  </tedi-modal-header>
+  <tedi-modal-content>
+    <!-- Content -->
+  </tedi-modal-content>
+  <tedi-modal-footer>
+    <button tedi-button variant="secondary" (click)="open = false">Cancel</button>
+    <button tedi-button (click)="open = false">Continue</button>
+  </tedi-modal-footer>
+</tedi-modal>`,
+        language: "html",
+        type: "code",
+      },
+    },
   },
   render: (args) => ({
     props: {
       ...args,
-      options: [
-        { value: "1", label: "Option 1" },
-        { value: "2", label: "Option 2" },
-        { value: "3", label: "Option 3" },
-        { value: "4", label: "Option 4" },
-        { value: "5", label: "Option 5" },
-      ],
+      open: false,
+      options: defaultOptions,
     },
     template: `
       <button tedi-button (click)="open = true">Open modal</button>
-      <tedi-modal [(open)]="open" [size]="size" [width]="width" [position]="position">
-        <tedi-modal-header [showClose]="showClose">
+      <tedi-modal [(open)]="open">
+        <tedi-modal-header>
           <h1>Title</h1>
         </tedi-modal-header>
         <tedi-modal-content>
@@ -178,220 +913,6 @@ export const Default: DefaultStory = {
           <button tedi-button variant="secondary" (click)="open = false">Cancel</button>
           <button tedi-button (click)="open = false">Continue</button>
         </tedi-modal-footer>
-      </tedi-modal>
-    `,
-  }),
-};
-
-export const Size: StoryObj<ModalComponent> = {
-  render: (args) => ({
-    props: {
-      ...args,
-      openDefault: false,
-      openSmall: false,
-      options: [
-        { value: "1", label: "Option 1" },
-        { value: "2", label: "Option 2" },
-        { value: "3", label: "Option 3" },
-        { value: "4", label: "Option 4" },
-        { value: "5", label: "Option 5" },
-      ],
-    },
-    template: `
-      <div style="display: flex; gap: 16px;">
-        <button tedi-button (click)="openSmall = true">Open small modal</button>
-        <button tedi-button (click)="openDefault = true">Open default modal</button>
-      </div>
-      <tedi-modal size="small" [(open)]="openSmall">
-        <tedi-modal-header>
-          <h1>Title</h1>
-        </tedi-modal-header>
-        <tedi-modal-content>
-          <div>
-            <label tedi-label for="select-1">Label</label>
-            <tedi-select inputId="select-1" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-          <div>
-            <label tedi-label for="select-2">Label</label>
-            <tedi-select inputId="select-2" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-        </tedi-modal-content>
-        <tedi-modal-footer>
-          <button tedi-button variant="secondary" (click)="openSmall = false">Cancel</button>
-          <button tedi-button (click)="openSmall = false">Continue</button>
-        </tedi-modal-footer>
-      </tedi-modal>
-      <tedi-modal [(open)]="openDefault">
-        <tedi-modal-header>
-          <h1>Title</h1>
-        </tedi-modal-header>
-        <tedi-modal-content>
-          <div>
-            <label tedi-label for="select-1">Label</label>
-            <tedi-select inputId="select-1" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-          <div>
-            <label tedi-label for="select-2">Label</label>
-            <tedi-select inputId="select-2" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-        </tedi-modal-content>
-        <tedi-modal-footer>
-          <button tedi-button variant="secondary" (click)="openDefault = false">Cancel</button>
-          <button tedi-button (click)="openDefault = false">Continue</button>
-        </tedi-modal-footer>
-      </tedi-modal>
-    `,
-  }),
-};
-
-export const FooterVariants: StoryObj<ModalComponent> = {
-  render: (args) => ({
-    props: {
-      ...args,
-      openDefault: false,
-      openLeftRight: false,
-      openThreeButtons: false,
-      openNoFooter: false,
-      options: [
-        { value: "1", label: "Option 1" },
-        { value: "2", label: "Option 2" },
-        { value: "3", label: "Option 3" },
-        { value: "4", label: "Option 4" },
-        { value: "5", label: "Option 5" },
-      ],
-    },
-    template: `
-      <div style="display: flex; gap: 16px;">
-        <button tedi-button (click)="openDefault = true">Open modal</button>
-        <button tedi-button (click)="openLeftRight = true">Open modal with left right buttons</button>
-        <button tedi-button (click)="openThreeButtons = true">Open modal with three buttons</button>
-        <button tedi-button (click)="openNoFooter = true">Open modal with no footer</button>
-      </div>
-      <tedi-modal size="small" [(open)]="openDefault">
-        <tedi-modal-header>
-          <h1>Title</h1>
-        </tedi-modal-header>
-        <tedi-modal-content>
-          <div>
-            <label tedi-label for="select-1">Label</label>
-            <tedi-select inputId="select-1" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-          <div>
-            <label tedi-label for="select-2">Label</label>
-            <tedi-select inputId="select-2" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-        </tedi-modal-content>
-        <tedi-modal-footer>
-          <button tedi-button variant="secondary" (click)="openDefault = false">Cancel</button>
-          <button tedi-button (click)="openDefault = false">Continue</button>
-        </tedi-modal-footer>
-      </tedi-modal>
-      <tedi-modal [(open)]="openLeftRight">
-        <tedi-modal-header>
-          <h1>Title</h1>
-        </tedi-modal-header>
-        <tedi-modal-content>
-          <div>
-            <label tedi-label for="select-1">Label</label>
-            <tedi-select inputId="select-1" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-          <div>
-            <label tedi-label for="select-2">Label</label>
-            <tedi-select inputId="select-2" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-        </tedi-modal-content>
-        <tedi-modal-footer style="justify-content: space-between;">
-          <button tedi-button variant="secondary" (click)="openLeftRight = false">Cancel</button>
-          <button tedi-button (click)="openLeftRight = false">Continue</button>
-        </tedi-modal-footer>
-      </tedi-modal>
-      <tedi-modal [(open)]="openThreeButtons">
-        <tedi-modal-header>
-          <h1>Title</h1>
-        </tedi-modal-header>
-        <tedi-modal-content>
-          <div>
-            <label tedi-label for="select-1">Label</label>
-            <tedi-select inputId="select-1" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-          <div>
-            <label tedi-label for="select-2">Label</label>
-            <tedi-select inputId="select-2" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-        </tedi-modal-content>
-        <tedi-modal-footer style="justify-content: space-between;">
-          <button tedi-button variant="neutral" (click)="openThreeButtons = false">
-            <tedi-icon name="arrow_back" />
-            Back
-          </button>
-          <div style="display: flex; gap: 16px;">
-            <button tedi-button variant="secondary" (click)="openThreeButtons = false">Cancel</button>
-            <button tedi-button (click)="openThreeButtons = false">Continue</button>
-          </div>
-        </tedi-modal-footer>
-      </tedi-modal>
-      <tedi-modal [(open)]="openNoFooter">
-        <tedi-modal-header>
-          <h1>Title</h1>
-        </tedi-modal-header>
-        <tedi-modal-content>
-          <div>
-            <label tedi-label for="select-1">Label</label>
-            <tedi-select inputId="select-1" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-          <div>
-            <label tedi-label for="select-2">Label</label>
-            <tedi-select inputId="select-2" state="default">
-              @for (option of options; track option.value) {
-                <tedi-select-option [value]="option.value" [label]="option.label" />
-              }
-            </tedi-select>
-          </div>
-        </tedi-modal-content>
       </tedi-modal>
     `,
   }),

--- a/tedi/components/overlay/modal/modal.types.ts
+++ b/tedi/components/overlay/modal/modal.types.ts
@@ -1,0 +1,35 @@
+import { InjectionToken } from "@angular/core";
+
+export type ModalSize = "default" | "small";
+export type ModalWidthPreset = "xs" | "sm" | "md" | "lg" | "xl";
+export type ModalWidth = ModalWidthPreset | (string & {});
+export type ModalPosition = "center" | "top" | "left" | "right";
+export type ModalScrollBehavior = "content" | "page";
+
+export interface ModalConfig<D = unknown> {
+  /** Data to pass to the modal content component. Accessible via `inject(MODAL_DATA)`. */
+  data?: D;
+  /** Modal size variant. @default 'default' */
+  size?: ModalSize;
+  /** Modal width preset. @default 'sm' */
+  width?: ModalWidth;
+  /** Position of the modal. @default 'center' */
+  position?: ModalPosition;
+  /** Scroll behavior when content overflows. 'content' scrolls inside the modal, 'page' scrolls the overlay. @default 'content' */
+  scrollBehavior?: ModalScrollBehavior;
+  /** Whether clicking the backdrop closes the modal. @default true */
+  closeOnBackdropClick?: boolean;
+  /** Whether pressing Escape closes the modal. @default true */
+  closeOnEscape?: boolean;
+  /** Whether to show a close button in the header. @default true */
+  showClose?: boolean;
+  /** Whether the modal becomes fullscreen on mobile viewports. @default false */
+  mobileFullscreen?: boolean;
+  /** ARIA label for the dialog. */
+  ariaLabel?: string;
+  /** ID of the element that labels the dialog. */
+  ariaLabelledBy?: string;
+}
+
+/** Injection token for data passed to a modal opened via ModalService. */
+export const MODAL_DATA = new InjectionToken<unknown>("TediModalData");

--- a/tedi/components/overlay/modal/modal.types.ts
+++ b/tedi/components/overlay/modal/modal.types.ts
@@ -5,6 +5,7 @@ export type ModalWidthPreset = "xs" | "sm" | "md" | "lg" | "xl";
 export type ModalWidth = ModalWidthPreset | (string & {});
 export type ModalPosition = "center" | "top" | "left" | "right";
 export type ModalScrollBehavior = "content" | "page";
+export type ModalFullscreen = boolean | "sm" | "md" | "lg" | "xl";
 
 export interface ModalConfig<D = unknown> {
   /** Data to pass to the modal content component. Accessible via `inject(MODAL_DATA)`. */
@@ -23,8 +24,8 @@ export interface ModalConfig<D = unknown> {
   closeOnEscape?: boolean;
   /** Whether to show a close button in the header. @default true */
   showClose?: boolean;
-  /** Whether the modal becomes fullscreen on mobile viewports. @default false */
-  mobileFullscreen?: boolean;
+  /** Fullscreen mode. `true` = always fullscreen, `'sm'`/`'md'`/etc = fullscreen below that breakpoint. @default false */
+  fullscreen?: ModalFullscreen;
   /** Max-width cap (e.g. '75%', '60vw'). Overrides the default 95vw limit. */
   maxWidth?: string;
   /** ARIA label for the dialog. */

--- a/tedi/components/overlay/modal/modal.types.ts
+++ b/tedi/components/overlay/modal/modal.types.ts
@@ -11,7 +11,7 @@ export interface ModalConfig<D = unknown> {
   data?: D;
   /** Modal size variant. @default 'default' */
   size?: ModalSize;
-  /** Modal width preset. @default 'sm' */
+  /** Modal width — preset ('xs'–'xl') or custom CSS value (e.g. '800px'). @default 'sm' */
   width?: ModalWidth;
   /** Position of the modal. @default 'center' */
   position?: ModalPosition;
@@ -25,6 +25,8 @@ export interface ModalConfig<D = unknown> {
   showClose?: boolean;
   /** Whether the modal becomes fullscreen on mobile viewports. @default false */
   mobileFullscreen?: boolean;
+  /** Max-width cap (e.g. '75%', '60vw'). Overrides the default 95vw limit. */
+  maxWidth?: string;
   /** ARIA label for the dialog. */
   ariaLabel?: string;
   /** ID of the element that labels the dialog. */


### PR DESCRIPTION
added scroll-fade helper

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ScrollFadeComponent and stories; added ModalService and ModalRef for programmatic modals.

* **Improvements**
  * Modal: service vs legacy modes, description slot, host classes, backdrop/close behavior, sizing/position/fullscreen/layout styles and CSS variables; story updates demonstrating variants.
  * Helpers: re-exported scroll-fade helper.

* **Tests**
  * Extensive unit and integration tests for scroll-fade, modal service, header, and modal behaviors.

* **Chores**
  * Stylelint now accepts cdk- class prefix; custom Jest env suppresses specific CSS parse errors and config updated to use it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->