### PR TITLE
fix(text-field): fix circular dependency issue when using with reactive forms #382

### DIFF
--- a/tedi/components/form/form-field/form-field-control.ts
+++ b/tedi/components/form/form-field/form-field-control.ts
@@ -13,12 +13,11 @@ export interface FormFieldControl<T = unknown> {
    * Whether the control is disabled.
    */
   disabled: Signal<boolean>;
-  /**
-   * Whether the control is currently in an invalid state.
-   * Usually derived from Angular form validation state.
-   */
+  /** Reactive invalid state (driven by FormField) */
   invalid: Signal<boolean>;
 
+  /** Called by FormField to update invalid state */
+  setInvalidState(isInvalid: boolean): void;
   /**
    * Optional method used by the form field clear button.
    * If implemented, the form field can trigger clearing the value.

--- a/tedi/components/form/form-field/form-field.component.spec.ts
+++ b/tedi/components/form/form-field/form-field.component.spec.ts
@@ -10,6 +10,8 @@ import {
   FormFieldControl,
 } from "./form-field-control";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
+import { NgControl } from "@angular/forms";
+import { Subject } from "rxjs";
 
 @Component({
   selector: "mock-control",
@@ -49,11 +51,11 @@ export class MockFeedbackComponent extends FeedbackTextComponent {}
       [inputClass]="inputClass"
     >
       <mock-control #mockControl></mock-control>
-      <tedi-feedback-text
+      <mock-feedback
         #feedback
         [text]="'Feedback text'"
         [type]="feedbackType"
-      ></tedi-feedback-text>
+      ></mock-feedback>
     </tedi-form-field>
   `,
 })
@@ -169,5 +171,24 @@ describe("FormFieldComponent", () => {
 
     const classes = formField.inputClasses() as Record<string, boolean>;
     expect(classes["custom-class"]).toBe(true);
+  });
+
+  it("should react to control.events and call setInvalidState", () => {
+    const events = new Subject<void>();
+
+    formField.ngControl = {
+      control: {
+        events: events.asObservable(),
+      },
+      invalid: true,
+      touched: true,
+      dirty: false,
+    } as unknown as NgControl;
+
+    formField.ngAfterContentInit();
+
+    events.next();
+
+    expect(host.mockControl.setInvalidState).toHaveBeenCalledWith(true);
   });
 });

--- a/tedi/components/form/form-field/form-field.component.spec.ts
+++ b/tedi/components/form/form-field/form-field.component.spec.ts
@@ -26,6 +26,7 @@ class MockControlComponent implements FormFieldControl<string> {
   value = signal("");
   disabled = signal(false);
   invalid = signal(false);
+  setInvalidState = jest.fn();
   clearField = jest.fn();
 }
 

--- a/tedi/components/form/form-field/form-field.component.spec.ts
+++ b/tedi/components/form/form-field/form-field.component.spec.ts
@@ -187,8 +187,12 @@ describe("FormFieldComponent", () => {
 
     formField.ngAfterContentInit();
 
+    const spy = jest.spyOn(host.mockControl, "setInvalidState");
+    spy.mockClear();
+
     events.next();
 
-    expect(host.mockControl.setInvalidState).toHaveBeenCalledWith(true);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(true);
   });
 });

--- a/tedi/components/form/form-field/form-field.component.ts
+++ b/tedi/components/form/form-field/form-field.component.ts
@@ -6,6 +6,8 @@ import {
   input,
   ViewEncapsulation,
   AfterContentInit,
+  inject,
+  DestroyRef,
 } from "@angular/core";
 import { NgClass } from "@angular/common";
 import {
@@ -24,6 +26,7 @@ import { SeparatorComponent } from "../../../components/helpers/separator/separa
 import { TediTranslationPipe } from "../../../services/translation/translation.pipe";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
 import { NgControl } from "@angular/forms";
+import { takeUntilDestroyed } from "@angular/core/rxjs-interop";
 
 export type InputSize = "small" | "large" | "default";
 export type InputState = "valid" | "error" | "default";
@@ -53,7 +56,6 @@ export interface FormFieldIcon {
   ],
   host: {
     "[class]": "hostClasses()",
-    "(focusout)": "onFocusOut()",
   },
 })
 export class FormFieldComponent implements AfterContentInit {
@@ -85,23 +87,13 @@ export class FormFieldComponent implements AfterContentInit {
   @ContentChild(FeedbackTextComponent)
   feedback?: FeedbackTextComponent;
 
+  private readonly destroyRef = inject(DestroyRef);
+
   ngAfterContentInit() {
-    if (this.ngControl?.statusChanges) {
-      this.ngControl.statusChanges.subscribe(() => {
-        this.updateValidationState();
-      });
-    }
+    this.ngControl?.control?.events
+      ?.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.updateValidationState());
 
-    if (this.ngControl?.valueChanges) {
-      this.ngControl.valueChanges.subscribe(() => {
-        this.updateValidationState();
-      });
-    }
-
-    this.updateValidationState();
-  }
-
-  onFocusOut() {
     this.updateValidationState();
   }
 
@@ -111,7 +103,7 @@ export class FormFieldComponent implements AfterContentInit {
     const dirty = !!this.ngControl?.dirty;
     const fieldInvalid = invalid && (touched || dirty);
 
-    this.control?.setInvalidState?.(fieldInvalid);
+    this.control?.setInvalidState(fieldInvalid);
   }
 
   readonly resolvedIcon = computed<FormFieldIcon | undefined>(() => {

--- a/tedi/components/form/form-field/form-field.component.ts
+++ b/tedi/components/form/form-field/form-field.component.ts
@@ -5,6 +5,7 @@ import {
   ContentChild,
   input,
   ViewEncapsulation,
+  AfterContentInit,
 } from "@angular/core";
 import { NgClass } from "@angular/common";
 import {
@@ -22,6 +23,7 @@ import { ClosingButtonComponent } from "../../../components/buttons/closing-butt
 import { SeparatorComponent } from "../../../components/helpers/separator/separator.component";
 import { TediTranslationPipe } from "../../../services/translation/translation.pipe";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
+import { NgControl } from "@angular/forms";
 
 export type InputSize = "small" | "large" | "default";
 export type InputState = "valid" | "error" | "default";
@@ -51,9 +53,10 @@ export interface FormFieldIcon {
   ],
   host: {
     "[class]": "hostClasses()",
+    "(focusout)": "onFocusOut()",
   },
 })
-export class FormFieldComponent {
+export class FormFieldComponent implements AfterContentInit {
   /**
    * The size of the form field.
    * @default "default"
@@ -76,8 +79,40 @@ export class FormFieldComponent {
   @ContentChild(TEDI_FORM_FIELD_CONTROL)
   control?: FormFieldControl;
 
+  @ContentChild(NgControl)
+  ngControl?: NgControl;
+
   @ContentChild(FeedbackTextComponent)
   feedback?: FeedbackTextComponent;
+
+  ngAfterContentInit() {
+    if (this.ngControl?.statusChanges) {
+      this.ngControl.statusChanges.subscribe(() => {
+        this.updateValidationState();
+      });
+    }
+
+    if (this.ngControl?.valueChanges) {
+      this.ngControl.valueChanges.subscribe(() => {
+        this.updateValidationState();
+      });
+    }
+
+    this.updateValidationState();
+  }
+
+  onFocusOut() {
+    this.updateValidationState();
+  }
+
+  private updateValidationState() {
+    const invalid = !!this.ngControl?.invalid;
+    const touched = !!this.ngControl?.touched;
+    const dirty = !!this.ngControl?.dirty;
+    const fieldInvalid = invalid && (touched || dirty);
+
+    this.control?.setInvalidState?.(fieldInvalid);
+  }
 
   readonly resolvedIcon = computed<FormFieldIcon | undefined>(() => {
     const icon = this.icon();
@@ -88,7 +123,7 @@ export class FormFieldComponent {
 
   readonly validationState = computed<ValidationState>(() => {
     const feedbackType = this.feedback?.type();
-    const fieldInvalid = this.control?.invalid();
+    const fieldInvalid = this.control?.invalid?.() ?? false;
 
     if (fieldInvalid || feedbackType === "error") return "invalid";
     if (feedbackType === "valid") return "valid";

--- a/tedi/components/form/text-field/text-field.component.spec.ts
+++ b/tedi/components/form/text-field/text-field.component.spec.ts
@@ -114,4 +114,15 @@ describe("TextFieldComponent", () => {
 
     expect(onTouchedSpy).toHaveBeenCalled();
   });
+
+  it("should update invalid signal via setInvalidState", () => {
+    const fixture = TestBed.createComponent(TextFieldComponent);
+    const component = fixture.componentInstance;
+
+    component.setInvalidState(true);
+    expect(component.invalid()).toBe(true);
+
+    component.setInvalidState(false);
+    expect(component.invalid()).toBe(false);
+  });
 });

--- a/tedi/components/form/text-field/text-field.component.ts
+++ b/tedi/components/form/text-field/text-field.component.ts
@@ -9,14 +9,8 @@ import {
   signal,
   output,
   ElementRef,
-  Self,
-  Optional,
 } from "@angular/core";
-import {
-  ControlValueAccessor,
-  NG_VALUE_ACCESSOR,
-  NgControl,
-} from "@angular/forms";
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 import {
   FormFieldControl,
   TEDI_FORM_FIELD_CONTROL,
@@ -65,22 +59,17 @@ export class TextFieldComponent
    */
   readonly clear = output<void>();
 
-  constructor(
-    private el: ElementRef<HTMLInputElement>,
-    @Optional() @Self() private ngControl: NgControl | null,
-  ) {
-    if (this.ngControl) {
-      this.ngControl.valueAccessor = this;
-    }
-  }
+  constructor(private el: ElementRef<HTMLInputElement>) {}
 
   readonly disabled = computed(
     () => this.el.nativeElement.disabled || this.formDisabled(),
   );
-  readonly invalid = computed(() => {
-    const control = this.ngControl?.control;
-    return !!(control?.invalid && (control?.touched || control?.dirty));
-  });
+
+  readonly invalid = signal(false);
+
+  setInvalidState(isInvalid: boolean) {
+    this.invalid.set(isInvalid);
+  }
 
   private formDisabled = signal(false);
   private onChange: (value: string) => void = () => {};

--- a/tedi/components/form/text-field/text-field.stories.ts
+++ b/tedi/components/form/text-field/text-field.stories.ts
@@ -1,4 +1,10 @@
 import {
+  FormControl,
+  FormsModule,
+  ReactiveFormsModule,
+  Validators,
+} from "@angular/forms";
+import {
   argsToTemplate,
   Meta,
   moduleMetadata,
@@ -34,6 +40,8 @@ export default {
         TextComponent,
         FormFieldComponent,
         FeedbackTextComponent,
+        ReactiveFormsModule,
+        FormsModule,
       ],
     }),
   ],
@@ -241,4 +249,60 @@ export const Placeholder: StoryObj<TextFieldComponent> = {
       </tedi-form-field>
     `,
   }),
+};
+
+export const WithTemplateDrivenForms: StoryObj<TextFieldComponent> = {
+  render: () => ({
+    props: {
+      inputValue: "",
+    },
+    template: `
+      <form #form="ngForm" style="display: flex; flex-direction: column; gap: var(--layout-grid-gutters-16);">
+        <tedi-form-field>
+              <label tedi-label for="example-template-form" [required]="true">Label</label>
+          <input
+            tedi-text-field
+                id="example-template-form"
+                name="example"
+            required
+            [(ngModel)]="inputValue"
+            #inputModel="ngModel"
+          />
+        </tedi-form-field>
+
+        <div>
+          <p>Value: {{ inputValue }}</p>
+          <p>Touched: {{ inputModel.touched }}</p>
+          <p>Dirty: {{ inputModel.dirty }}</p>
+          <p>Invalid: {{ inputModel.invalid }}</p>
+        </div>
+      </form>
+    `,
+  }),
+};
+
+export const WithReactiveForms: StoryObj<TextFieldComponent> = {
+  render: () => {
+    const control = new FormControl("", { nonNullable: true });
+    control.setValidators([Validators.required]);
+
+    return {
+      props: { control },
+      template: `
+        <div style="display: flex; flex-direction: column; gap: var(--layout-grid-gutters-16);">
+          <tedi-form-field>
+            <label tedi-label [for]="'example-reactive-form'" [required]="true">Label</label>
+            <input tedi-text-field id="example-reactive-form" [formControl]="control" />
+          </tedi-form-field>
+
+          <div>
+            <p>Value: {{ control.value }}</p>
+            <p>Touched: {{ control.touched }}</p>
+            <p>Dirty: {{ control.dirty }}</p>
+            <p>Invalid: {{ control.invalid }}</p>
+          </div>
+        </div>
+      `,
+    };
+  },
 };

--- a/tedi/components/form/text-field/text-field.stories.ts
+++ b/tedi/components/form/text-field/text-field.stories.ts
@@ -283,8 +283,10 @@ export const WithTemplateDrivenForms: StoryObj<TextFieldComponent> = {
 
 export const WithReactiveForms: StoryObj<TextFieldComponent> = {
   render: () => {
-    const control = new FormControl("", { nonNullable: true });
-    control.setValidators([Validators.required]);
+    const control = new FormControl("", {
+      nonNullable: true,
+      validators: [Validators.required],
+    });
 
     return {
       props: { control },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Validation state now syncs reliably between form fields and inputs so invalid/touched/dirty status is reflected consistently (including ARIA invalid).

* **New Features**
  * Storybook examples showing text field usage with template-driven and reactive forms.

* **Tests**
  * Added unit tests ensuring invalid-state updates propagate correctly between fields and controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->