### PR TITLE
feat(tabs): add tab-card and tabs-vertical #14

### DIFF
--- a/community/components/navigation/tabs/tab-card/tab-card.component.html
+++ b/community/components/navigation/tabs/tab-card/tab-card.component.html
@@ -1,0 +1,8 @@
+<tedi-card>
+  <tedi-card-content class="tedi-tab-card__content">
+    <h3>{{ title() }}</h3>
+    <div tedi-button variant="neutral">
+      <tedi-icon name="arrow_forward" class="tedi-tab-card__action-icon" [size]="18"/>
+    </div>
+  </tedi-card-content>
+</tedi-card>

--- a/community/components/navigation/tabs/tab-card/tab-card.component.html
+++ b/community/components/navigation/tabs/tab-card/tab-card.component.html
@@ -2,7 +2,7 @@
   <tedi-card-content class="tedi-tab-card__content">
     <h3>{{ title() }}</h3>
     <div tedi-button variant="neutral">
-      <tedi-icon name="arrow_forward" class="tedi-tab-card__action-icon" [size]="18"/>
+      <tedi-icon name="arrow_forward" class="tedi-tab-card__action-icon" [size]="18" color="inherit"/>
     </div>
   </tedi-card-content>
 </tedi-card>

--- a/community/components/navigation/tabs/tab-card/tab-card.component.scss
+++ b/community/components/navigation/tabs/tab-card/tab-card.component.scss
@@ -1,0 +1,24 @@
+.tedi-tab-card {
+  width: 100%;
+
+  &__content.tedi-card-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--dimensions-13);
+    color: var(--tab-item-active-text);
+    width: 100%;
+  }
+
+  &__action-icon {
+    cursor: pointer;
+  }
+
+  &--disabled {
+    pointer-events: none;
+
+    .tedi-card-content {
+      color: var(--general-text-disabled);
+    }
+  }
+}

--- a/community/components/navigation/tabs/tab-card/tab-card.component.ts
+++ b/community/components/navigation/tabs/tab-card/tab-card.component.ts
@@ -1,0 +1,44 @@
+import {booleanAttribute, ChangeDetectionStrategy, Component, input, model, ViewEncapsulation} from '@angular/core';
+import {ButtonComponent, IconComponent} from "@tedi-design-system/angular/tedi";
+import {CardComponent, CardContentComponent} from "@tedi-design-system/angular/community";
+
+@Component({
+  selector: '[tedi-tab-card]',
+  imports: [
+    ButtonComponent,
+    CardComponent,
+    CardContentComponent,
+    IconComponent
+  ],
+  templateUrl: './tab-card.component.html',
+  styleUrl: './tab-card.component.scss',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    "[class.tedi-tab-card]": "true",
+    "[class.tedi-tab-card--disabled]": "disabledInput()",
+    "[attr.role]": "'tab'",
+    "[attr.aria-selected]": "selected()",
+    "[attr.aria-disabled]": "disabledInput()",
+    "(click)": "selectTab()",
+  },
+})
+export class TabCardComponent {
+  readonly tabId = input.required<string>();
+  readonly title = input.required<string>();
+  readonly selected = model(false);
+
+  readonly disabledInput = input(false, {
+    transform: booleanAttribute,
+    // eslint-disable-next-line @angular-eslint/no-input-rename
+    alias: "disabled",
+  });
+
+  selectTab() {
+    if (this.disabledInput()) {
+      return;
+    }
+
+    this.selected.set(true);
+  }
+}

--- a/community/components/navigation/tabs/tab-card/tab-card.component.ts
+++ b/community/components/navigation/tabs/tab-card/tab-card.component.ts
@@ -1,9 +1,10 @@
-import {booleanAttribute, ChangeDetectionStrategy, Component, input, model, ViewEncapsulation} from '@angular/core';
+import {booleanAttribute, ChangeDetectionStrategy, Component, input, model, output, ViewEncapsulation} from '@angular/core';
 import {ButtonComponent, IconComponent} from "@tedi-design-system/angular/tedi";
 import {CardComponent, CardContentComponent} from "@tedi-design-system/angular/community";
 
 @Component({
   selector: '[tedi-tab-card]',
+  standalone: true,
   imports: [
     ButtonComponent,
     CardComponent,
@@ -20,13 +21,18 @@ import {CardComponent, CardContentComponent} from "@tedi-design-system/angular/c
     "[attr.role]": "'tab'",
     "[attr.aria-selected]": "selected()",
     "[attr.aria-disabled]": "disabledInput()",
+    "[attr.tabindex]": "selected() ? 0 : -1",
+    "[attr.aria-controls]": "tabId() + '-panel'",
     "(click)": "selectTab()",
+    "(keydown.enter)": "selectTab()",
+    "(keydown.space)": "onSpaceKey($event)",
   },
 })
 export class TabCardComponent {
   readonly tabId = input.required<string>();
   readonly title = input.required<string>();
   readonly selected = model(false);
+  readonly tabSelected = output<string>();
 
   readonly disabledInput = input(false, {
     transform: booleanAttribute,
@@ -40,5 +46,11 @@ export class TabCardComponent {
     }
 
     this.selected.set(true);
+    this.tabSelected.emit(this.tabId());
+  }
+
+  onSpaceKey(event: Event) {
+    event.preventDefault();
+    this.selectTab();
   }
 }

--- a/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.html
+++ b/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.html
@@ -1,0 +1,22 @@
+<ng-template #tabsList>
+  <ng-content select="[tedi-tab-card]"/>
+</ng-template>
+
+@if (activeTabContent(); as activeContent) {
+  <button tedi-button type="button" variant="neutral" class="tedi-tabs-vertical__back-link" (click)="unselectAllTabs()">
+    <tedi-icon name="arrow_back" [size]="18"/>
+    <span>{{ "back" | tediTranslate }}</span>
+  </button>
+
+  <h3 tedi-text>{{ activeTabTitle() }}</h3>
+
+  <tedi-card class="tedi-tabs-vertical__card">
+    <tedi-card-content>
+      <ng-container *ngTemplateOutlet="activeContent"/>
+    </tedi-card-content>
+  </tedi-card>
+} @else {
+  <tedi-accordion class="tedi-tabs-vertical__accordion" role="tablist">
+    <ng-container *ngTemplateOutlet="tabsList"/>
+  </tedi-accordion>
+}

--- a/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.html
+++ b/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.html
@@ -4,13 +4,13 @@
 
 @if (activeTabContent(); as activeContent) {
   <button tedi-button type="button" variant="neutral" class="tedi-tabs-vertical__back-link" (click)="unselectAllTabs()">
-    <tedi-icon name="arrow_back" [size]="18"/>
+    <tedi-icon name="arrow_back" [size]="18" color="inherit"/>
     <span>{{ "back" | tediTranslate }}</span>
   </button>
 
   <h3 tedi-text>{{ activeTabTitle() }}</h3>
 
-  <tedi-card class="tedi-tabs-vertical__card">
+  <tedi-card class="tedi-tabs-vertical__card" role="tabpanel" [id]="activeTabId() + '-panel'" [attr.aria-labelledby]="activeTabId()">
     <tedi-card-content>
       <ng-container *ngTemplateOutlet="activeContent"/>
     </tedi-card-content>

--- a/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.scss
+++ b/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.scss
@@ -1,0 +1,23 @@
+.tedi-tabs-vertical {
+  display: flex;
+  flex-direction: column;
+  align-items: start;
+  gap: var(--dimensions-10);
+
+  &__accordion,
+  &__card {
+    width: 100%;
+  }
+
+  &__back-link.tedi-button {
+    display: flex;
+    align-items: center;
+    gap: var(--dimensions-03);
+    cursor: pointer;
+    padding: var(--dimensions-02) var(--dimensions-03);
+  }
+
+  &__back-link > * {
+    color: var(--button-main-neutral-text-active);
+  }
+}

--- a/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.ts
+++ b/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.ts
@@ -1,13 +1,9 @@
 import {ChangeDetectionStrategy, Component, computed, contentChildren, ViewEncapsulation} from '@angular/core';
+import {outputToObservable, takeUntilDestroyed, toObservable} from '@angular/core/rxjs-interop';
+import {EMPTY, merge, switchMap} from 'rxjs';
 import {CardComponent, CardContentComponent, TabContentComponent} from "@tedi-design-system/angular/community";
 import {TabCardComponent} from "../tab-card/tab-card.component";
-import {
-  AccordionComponent,
-  ButtonComponent,
-  IconComponent,
-  TediTranslationPipe,
-  TextComponent
-} from "@tedi-design-system/angular/tedi";
+import {AccordionComponent, ButtonComponent, IconComponent, TediTranslationPipe, TextComponent} from "@tedi-design-system/angular/tedi";
 import {NgTemplateOutlet} from "@angular/common";
 
 @Component({
@@ -33,6 +29,19 @@ import {NgTemplateOutlet} from "@angular/common";
 export class TabsVerticalComponent {
   private readonly tabs = contentChildren(TabCardComponent);
   private readonly tabContents = contentChildren(TabContentComponent);
+
+  constructor() {
+    toObservable(this.tabs).pipe(
+      switchMap(tabs =>
+        tabs.length === 0
+          ? EMPTY
+          : merge(...tabs.map(t => outputToObservable(t.tabSelected)))
+      ),
+      takeUntilDestroyed()
+    ).subscribe(tabId => {
+      this.tabs().forEach(t => t.selected.set(t.tabId() === tabId));
+    });
+  }
 
   activeTabId = computed(() =>
     this.tabs().find((tab) => tab.selected())?.tabId()

--- a/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.ts
+++ b/community/components/navigation/tabs/tabs-vertical/tabs-vertical.component.ts
@@ -1,0 +1,52 @@
+import {ChangeDetectionStrategy, Component, computed, contentChildren, ViewEncapsulation} from '@angular/core';
+import {CardComponent, CardContentComponent, TabContentComponent} from "@tedi-design-system/angular/community";
+import {TabCardComponent} from "../tab-card/tab-card.component";
+import {
+  AccordionComponent,
+  ButtonComponent,
+  IconComponent,
+  TediTranslationPipe,
+  TextComponent
+} from "@tedi-design-system/angular/tedi";
+import {NgTemplateOutlet} from "@angular/common";
+
+@Component({
+  selector: 'tedi-tabs-vertical',
+  imports: [
+    AccordionComponent,
+    ButtonComponent,
+    CardComponent,
+    CardContentComponent,
+    IconComponent,
+    NgTemplateOutlet,
+    TediTranslationPipe,
+    TextComponent
+  ],
+  templateUrl: './tabs-vertical.component.html',
+  styleUrl: './tabs-vertical.component.scss',
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    "[class.tedi-tabs-vertical]": "true",
+  },
+})
+export class TabsVerticalComponent {
+  private readonly tabs = contentChildren(TabCardComponent);
+  private readonly tabContents = contentChildren(TabContentComponent);
+
+  activeTabId = computed(() =>
+    this.tabs().find((tab) => tab.selected())?.tabId()
+  );
+
+  activeTabTitle = computed(() =>
+    this.tabs().find((tab) => tab.selected())?.title()
+  );
+
+  activeTabContent = computed(() =>
+    this.tabContents().find((content) => content.tabId() === this.activeTabId())?.content()
+  );
+
+  unselectAllTabs() {
+    this.tabs().forEach(tab => tab.selected.set(false));
+  }
+}

--- a/community/components/navigation/tabs/tabs.stories.ts
+++ b/community/components/navigation/tabs/tabs.stories.ts
@@ -1,9 +1,11 @@
-import { Meta, moduleMetadata, StoryFn, StoryObj } from "@storybook/angular";
+import {Meta, moduleMetadata, StoryFn, StoryObj} from "@storybook/angular";
 
-import { CommonModule } from "@angular/common";
-import { TabsComponent } from "./tabs.component";
-import { TabComponent } from "./tab/tab.component";
-import { TabContentComponent } from "./tab-content/tab-content.component";
+import {CommonModule} from "@angular/common";
+import {TabsComponent} from "./tabs.component";
+import {TabComponent} from "./tab/tab.component";
+import {TabContentComponent} from "./tab-content/tab-content.component";
+import {TabCardComponent} from "./tab-card/tab-card.component";
+import {TabsVerticalComponent} from "./tabs-vertical/tabs-vertical.component";
 
 /**
  * <p>Tabs allow to group content into separate chunks to be displayed one at the time.</p>
@@ -17,7 +19,7 @@ export default {
   decorators: [
     moduleMetadata({
       declarations: [],
-      imports: [CommonModule, TabsComponent, TabComponent, TabContentComponent],
+      imports: [CommonModule, TabsComponent, TabComponent, TabContentComponent, TabCardComponent, TabsVerticalComponent],
     }),
   ],
   argTypes: {
@@ -25,7 +27,7 @@ export default {
       description: "Tab unique id",
       table: {
         category: "tab",
-        type: { summary: "string" },
+        type: {summary: "string"},
       },
     },
     selected: {
@@ -33,16 +35,16 @@ export default {
         "Whether tab is initially selected. Should be used only for non routed tabs",
       table: {
         category: "tab",
-        type: { summary: "boolean" },
-        defaultValue: { summary: "false" },
+        type: {summary: "boolean"},
+        defaultValue: {summary: "false"},
       },
     },
     disabled: {
       description: "Whether tab is disabled",
       table: {
         category: "tab",
-        type: { summary: "boolean" },
-        defaultValue: { summary: "false" },
+        type: {summary: "boolean"},
+        defaultValue: {summary: "false"},
       },
     },
     contentTabId: {
@@ -50,14 +52,39 @@ export default {
       description: "Id that matches `tabId` given to the `tedi-tab` component",
       table: {
         category: "tab-content",
-        type: { summary: "string" },
+        type: {summary: "string"},
+      },
+    },
+    tabCardId: {
+      name: "tabId",
+      description: "Tab unique id",
+      table: {
+        category: "tab-card",
+        type: {summary: "string"},
+      },
+    },
+    tabCardTitle: {
+      name: "title",
+      description: "Tab title",
+      table: {
+        category: "tab-card",
+        type: {summary: "string"},
+      },
+    },
+    tabCardDisabled: {
+      name: "disabled",
+      description: "Whether tab is disabled",
+      table: {
+        category: "tab-card",
+        type: {summary: "boolean"},
+        defaultValue: {summary: "false"},
       },
     },
   },
 } as Meta<TabComponent>;
 
-const TabsTemplate: StoryFn<TabComponent> = ({ ...args }) => ({
-  props: { ...args },
+const TabsTemplate: StoryFn<TabComponent> = ({...args}) => ({
+  props: {...args},
   template: `
     <tedi-tabs>
       <button tedi-tab [selected]="true" tabId="tab-1">Tab 1</button>
@@ -76,16 +103,37 @@ const TabsTemplate: StoryFn<TabComponent> = ({ ...args }) => ({
   `,
 });
 
-const RoutedTabTemplate: StoryFn<TabComponent> = ({ ...args }) => ({
-  props: { ...args },
+const RoutedTabTemplate: StoryFn<TabComponent> = ({...args}) => ({
+  props: {...args},
   template: `
     <tedi-tabs>
       <a tedi-tab routerLink="1" tabId="tab-1">Tab 1</a>
       <a tedi-tab routerLink="2" tabId="tab-2">Tab 2</a>
       <a tedi-tab routerLink="3">Tab 3</a>
-      
+
       router-outlet goes here
     </tedi-tabs>
+  `,
+});
+
+const VerticalTabTemplate: StoryFn<TabComponent> = ({...args}) => ({
+  props: {...args},
+  template: `
+    <tedi-tabs-vertical>
+      <div tedi-tab-card tabId="tab-1" title="Tab 1"></div>
+      <div tedi-tab-card tabId="tab-2" title="Tab 2"></div>
+      <div tedi-tab-card tabId="tab-3" title="Tab 3 (disabled)" [disabled]="true"></div>
+
+      <tedi-tab-content tabId="tab-1">
+        Tab 1 content
+      </tedi-tab-content>
+      <tedi-tab-content tabId="tab-2">
+        Tab 2 content
+      </tedi-tab-content>
+      <tedi-tab-content tabId="tab-3">
+        Tab 3 content
+      </tedi-tab-content>
+    </tedi-tabs-vertical>
   `,
 });
 
@@ -97,4 +145,8 @@ export const Default: TableStylesStory = {
 
 export const RoutedTabs: TableStylesStory = {
   render: RoutedTabTemplate,
+};
+
+export const VerticalTabs: TableStylesStory = {
+  render: VerticalTabTemplate,
 };

--- a/tedi/services/translation/translations.ts
+++ b/tedi/services/translation/translations.ts
@@ -65,6 +65,12 @@ export const translationsMap = {
     en: "Breadcrumbs",
     ru: "Навигационная цепочка",
   },
+  "back": {
+    components: ["Tabs"],
+    et: "Tagasi",
+    en: "Back",
+    ru: "Назад",
+  },
   more: {
     components: ["Tabs"],
     et: "Veel",


### PR DESCRIPTION
feat(tabs): add tab-card and tabs-vertical #14: Add tab-card and tabs-vertical component

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Vertical tabs navigation with selectable tab cards, titles, disabled state, and a back button to return from an active tab view.
  * Localized "Back" label added (et/en/ru).
  * Storybook updated with a new Vertical Tabs demo showcasing usage.

* **Style**
  * New styling for full-width tab cards, vertical layout, spacing, action icon cursor, and disabled visuals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TEDI-Design-System/angular/pull/402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->