### PR TITLE
feat(checkbox,radio): added formControl support to groups #412

### DIFF
--- a/skills/tedi-angular/references/components.md
+++ b/skills/tedi-angular/references/components.md
@@ -201,9 +201,49 @@ Composed of sub-components:
 **Inputs:**
 - `size: CheckboxSize = "default"` — "default" or "large"
 - `invalid: boolean = false`
+- `value: string` — identity within a `<tedi-checkbox-group>` (required when the group is form-bound)
+- `disabled: boolean = false`
 
 ```html
+<!-- Standalone checkbox -->
 <input type="checkbox" tedi-checkbox [formControl]="agreeControl" />
+
+<!-- Inside a form-bound group — [value] identifies the option -->
+<tedi-checkbox-group [formControl]="tagsControl">
+  <input type="checkbox" tedi-checkbox value="urgent" />
+  <input type="checkbox" tedi-checkbox value="review" />
+</tedi-checkbox-group>
+```
+
+### CheckboxGroup
+**Selector:** `tedi-checkbox-group` | ControlValueAccessor
+**Value type:** `string[]`
+**Inputs:**
+- `label: string` — visible label above the group
+- `direction: CheckboxGroupDirection = "horizontal"` — "horizontal" or "vertical"
+- `disabled: boolean = false` — propagates to all children
+- `ariaLabel: string` — accessible name when no visible `label` is rendered
+- `ariaLabelledby: string` — ID of an external element that labels the group
+**Models:** `values: string[]`
+
+Coordinates `checked` state across child `input[tedi-checkbox]` elements via their `[value]`. The group renders as a passive visual wrapper until a `FormControl` binds or `[(values)]` / `[values]` is bound with a non-empty array — at that point it applies `role="group"`, ARIA wiring, and takes over child `checked` state. For a null/empty initial value, use a `FormControl`:
+
+```typescript
+tagsControl = new FormControl<string[]>([]);
+```
+
+```html
+<tedi-checkbox-group [formControl]="tagsControl" label="Tags">
+  <input type="checkbox" tedi-checkbox value="urgent" />
+  <input type="checkbox" tedi-checkbox value="review" />
+  <input type="checkbox" tedi-checkbox value="draft" />
+</tedi-checkbox-group>
+
+<!-- Two-way binding with a preselected value -->
+<tedi-checkbox-group [(values)]="selected" label="Tags">
+  <input type="checkbox" tedi-checkbox value="a" />
+  <input type="checkbox" tedi-checkbox value="b" />
+</tedi-checkbox-group>
 ```
 
 ### Radio
@@ -211,12 +251,53 @@ Composed of sub-components:
 **Inputs:**
 - `size: RadioSize = "default"` — "default" or "large"
 - `invalid: boolean = false`
+- `value: string` — identity within a `<tedi-radio-group>` (required when the group is form-bound)
+- `disabled: boolean = false`
 
 ```html
+<!-- Standalone radio (consumer-managed name) -->
 <label tedi-label color="primary" style="display: inline-flex; align-items: center; gap: 8px;">
   <input type="radio" tedi-radio name="group" value="a" />
   Option A
 </label>
+
+<!-- Inside a form-bound group -->
+<tedi-radio-group [formControl]="statusControl">
+  <input type="radio" tedi-radio value="all" />
+  <input type="radio" tedi-radio value="active" />
+</tedi-radio-group>
+```
+
+### RadioGroup
+**Selector:** `tedi-radio-group` | ControlValueAccessor
+**Value type:** `string | null`
+**Inputs:**
+- `label: string` — visible label above the group
+- `direction: RadioGroupDirection = "horizontal"` — "horizontal" or "vertical"
+- `name: string` — shared `name` attribute for child radios (auto-generated when omitted). Pass explicitly to avoid SSR hydration mismatches.
+- `disabled: boolean = false` — propagates to all children
+- `ariaLabel: string` — accessible name when no visible `label` is rendered
+- `ariaLabelledby: string` — ID of an external element that labels the group
+**Models:** `value: string | null`
+
+Coordinates `checked` state across child `input[tedi-radio]` elements via their `[value]`. Passive visual wrapper until a `FormControl` binds or `[(value)]` / `[value]` is bound with a non-null value. For a null initial value, use a `FormControl`:
+
+```typescript
+statusControl = new FormControl<string | null>(null);
+```
+
+```html
+<tedi-radio-group [formControl]="statusControl" label="Status">
+  <input type="radio" tedi-radio value="all" />
+  <input type="radio" tedi-radio value="active" />
+  <input type="radio" tedi-radio value="done" />
+</tedi-radio-group>
+
+<!-- Two-way binding with a preselected value -->
+<tedi-radio-group [(value)]="status" label="Status">
+  <input type="radio" tedi-radio value="all" />
+  <input type="radio" tedi-radio value="active" />
+</tedi-radio-group>
 ```
 
 ### RadioCard
@@ -235,17 +316,17 @@ Composed of sub-components:
   </label>
 </div>
 
-<!-- Grouped cards -->
-<div style="display: inline-flex;">
+<!-- Grouped cards inside a form-bound RadioGroup -->
+<tedi-radio-group [formControl]="planControl">
   <label tedi-radio-card variant="primary" [grouped]="true">
-    <input tedi-radio type="radio" name="cards" />
-    Option A
+    <input tedi-radio type="radio" value="basic" />
+    Basic
   </label>
   <label tedi-radio-card variant="primary" [grouped]="true">
-    <input tedi-radio type="radio" name="cards" />
-    Option B
+    <input tedi-radio type="radio" value="pro" />
+    Pro
   </label>
-</div>
+</tedi-radio-group>
 ```
 
 ### Toggle

--- a/skills/tedi-angular/references/forms.md
+++ b/skills/tedi-angular/references/forms.md
@@ -9,6 +9,8 @@ TEDI form controls implement Angular's `ControlValueAccessor` interface, integra
 | TextFieldComponent | `input[tedi-text-field]` | `string` |
 | NumberFieldComponent | `tedi-number-field` | `number` |
 | CheckboxComponent | `input[tedi-checkbox]` | `boolean` |
+| CheckboxGroupComponent | `tedi-checkbox-group` | `string[]` |
+| RadioGroupComponent | `tedi-radio-group` | `string \| null` |
 | ToggleComponent | `tedi-toggle` | `boolean` |
 | DatePickerComponent | `tedi-date-picker` | `Date \| null` |
 | DropdownComponent | `tedi-dropdown` | `string` |
@@ -92,7 +94,20 @@ TEDI controls also support two-way binding via `model()` signals:
 <tedi-date-picker [(selected)]="selectedDate" />
 <tedi-dropdown [(value)]="selectedOption" />
 <tedi-toggle [(value)]="isEnabled" />
+
+<!-- Checkbox / radio groups — children identified by [value] -->
+<tedi-checkbox-group [(values)]="selectedTags">
+  <input type="checkbox" tedi-checkbox value="a" />
+  <input type="checkbox" tedi-checkbox value="b" />
+</tedi-checkbox-group>
+
+<tedi-radio-group [(value)]="status">
+  <input type="radio" tedi-radio value="active" />
+  <input type="radio" tedi-radio value="archived" />
+</tedi-radio-group>
 ```
+
+**Note:** `tedi-checkbox-group` / `tedi-radio-group` activate their form-control behavior only when a `FormControl` is bound or the two-way-bound value is non-null / non-empty. For null/empty initial values, prefer a `FormControl` — `new FormControl<string[]>([])` or `new FormControl<string | null>(null)`. Without any binding, the group is a passive visual wrapper.
 
 ## Validation States
 

--- a/tedi/components/form/checkbox-card/checkbox-card.component.scss
+++ b/tedi/components/form/checkbox-card/checkbox-card.component.scss
@@ -72,8 +72,8 @@ label[tedi-checkbox-card] {
   }
 
   &:has(input:focus-visible) {
-    outline: 2px solid var(--form-input-border-active);
-    outline-offset: 1px;
+    outline: var(--tedi-borders-02) solid var(--tedi-primary-500);
+    outline-offset: var(--tedi-borders-01);
 
     input[tedi-checkbox]:focus-visible {
       outline: none;
@@ -154,8 +154,7 @@ label[tedi-checkbox-card] {
       --_card-text: var(--form-checkbox-radio-card-secondary-selected-text);
       --_card-border: var(--form-checkbox-radio-card-secondary-selected-border);
 
-      outline: 1px solid var(--_card-border);
-      outline-offset: -2px;
+      box-shadow: inset 0 0 0 var(--tedi-borders-01) var(--_card-border);
     }
 
     &:has(input:hover:not(:disabled)) {
@@ -187,8 +186,7 @@ label[tedi-checkbox-card] {
         --form-checkbox-radio-card-secondary-disabled-selected-border
       );
 
-      outline: 1px solid var(--_card-border);
-      outline-offset: -2px;
+      box-shadow: inset 0 0 0 var(--tedi-borders-01) var(--_card-border);
     }
   }
 }

--- a/tedi/components/form/checkbox-group/checkbox-group.component.html
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.html
@@ -1,5 +1,5 @@
 @if (label()) {
-  <p class="tedi-checkbox-group__label" tedi-text color="secondary">{{ label() }}</p>
+  <p [id]="labelId" class="tedi-checkbox-group__label" tedi-text color="secondary">{{ label() }}</p>
 }
 <div class="tedi-checkbox-group__checks" [class.tedi-checkbox-group__checks--vertical]="direction() === 'vertical'">
   <ng-content />

--- a/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
@@ -1,10 +1,13 @@
 import { Component } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import {
   CheckboxGroupComponent,
   CheckboxGroupDirection,
 } from "./checkbox-group.component";
 import { CheckboxComponent } from "../checkbox/checkbox.component";
+import { CheckboxCardComponent } from "../checkbox-card/checkbox-card.component";
+import { CheckboxCardGroupComponent } from "../checkbox-card-group/checkbox-card-group.component";
 import { LabelComponent } from "../label/label.component";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
 
@@ -100,5 +103,245 @@ describe("CheckboxGroupComponent", () => {
     );
     const feedbackText = subtexts?.querySelector("tedi-feedback-text");
     expect(feedbackText).toBeTruthy();
+  });
+
+  it("should not set role when unmanaged (back-compat)", () => {
+    expect(groupElement.getAttribute("role")).toBeNull();
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
+  template: `
+    <tedi-checkbox-group [formControl]="control" label="Tags">
+      <input tedi-checkbox type="checkbox" value="urgent" />
+      <input tedi-checkbox type="checkbox" value="review" />
+      <input tedi-checkbox type="checkbox" value="draft" />
+    </tedi-checkbox-group>
+  `,
+})
+class FormControlHostComponent {
+  control = new FormControl<string[]>([]);
+}
+
+describe("CheckboxGroupComponent — managed with FormControl", () => {
+  let fixture: ComponentFixture<FormControlHostComponent>;
+  let groupElement: HTMLElement;
+  let inputs: HTMLInputElement[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FormControlHostComponent],
+    });
+
+    fixture = TestBed.createComponent(FormControlHostComponent);
+    fixture.detectChanges();
+    groupElement = fixture.nativeElement.querySelector("tedi-checkbox-group");
+    inputs = Array.from(
+      groupElement.querySelectorAll('input[type="checkbox"]')
+    ) as HTMLInputElement[];
+  });
+
+  it("should apply role=group when managed", () => {
+    expect(groupElement.getAttribute("role")).toBe("group");
+  });
+
+  it("should apply aria-label from label input", () => {
+    expect(groupElement.getAttribute("aria-label")).toBe("Tags");
+  });
+
+  it("should reflect FormControl value into native checked state", () => {
+    fixture.componentInstance.control.setValue(["urgent", "draft"]);
+    fixture.detectChanges();
+    expect(inputs[0].checked).toBe(true);
+    expect(inputs[1].checked).toBe(false);
+    expect(inputs[2].checked).toBe(true);
+  });
+
+  it("should toggle on child check/uncheck", () => {
+    inputs[0].checked = true;
+    inputs[0].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.control.value).toEqual(["urgent"]);
+
+    inputs[1].checked = true;
+    inputs[1].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.control.value).toEqual([
+      "urgent",
+      "review",
+    ]);
+
+    inputs[0].checked = false;
+    inputs[0].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.control.value).toEqual(["review"]);
+  });
+
+  it("should propagate disabled from FormControl to children", () => {
+    fixture.componentInstance.control.disable();
+    fixture.detectChanges();
+    expect(inputs.every((i) => i.disabled)).toBe(true);
+    expect(groupElement.getAttribute("aria-disabled")).toBe("true");
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
+  template: `
+    <tedi-checkbox-group [formControl]="control">
+      <input tedi-checkbox type="checkbox" value="a" />
+      <input tedi-checkbox type="checkbox" value="b" disabled />
+    </tedi-checkbox-group>
+  `,
+})
+class IntrinsicDisabledHostComponent {
+  control = new FormControl<string[]>([]);
+}
+
+describe("CheckboxGroupComponent — per-item disabled", () => {
+  it("should preserve intrinsic disabled across group-disabled toggles", () => {
+    TestBed.configureTestingModule({
+      imports: [IntrinsicDisabledHostComponent],
+    });
+    const fixture = TestBed.createComponent(IntrinsicDisabledHostComponent);
+    fixture.detectChanges();
+    const inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="checkbox"]'
+      )
+    ) as HTMLInputElement[];
+
+    // Intrinsic disabled preserved initially.
+    expect(inputs[0].disabled).toBe(false);
+    expect(inputs[1].disabled).toBe(true);
+
+    // Disabling the FormControl disables all.
+    fixture.componentInstance.control.disable();
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(true);
+    expect(inputs[1].disabled).toBe(true);
+
+    // Re-enabling the FormControl restores intrinsic per-item state.
+    fixture.componentInstance.control.enable();
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(false);
+    expect(inputs[1].disabled).toBe(true);
+  });
+
+  it("should not update values when intrinsically disabled child fires change", () => {
+    TestBed.configureTestingModule({
+      imports: [IntrinsicDisabledHostComponent],
+    });
+    const fixture = TestBed.createComponent(IntrinsicDisabledHostComponent);
+    fixture.detectChanges();
+    const inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="checkbox"]'
+      )
+    ) as HTMLInputElement[];
+
+    // Simulate click on disabled input (shouldn't normally fire, but guard anyway).
+    inputs[1].checked = true;
+    inputs[1].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.control.value).toEqual([]);
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [CheckboxGroupComponent, CheckboxComponent],
+  template: `
+    <tedi-checkbox-group [(values)]="selected">
+      <input tedi-checkbox type="checkbox" value="a" />
+      <input tedi-checkbox type="checkbox" value="b" />
+    </tedi-checkbox-group>
+  `,
+})
+class TwoWayHostComponent {
+  selected: string[] = ["a"];
+}
+
+describe("CheckboxGroupComponent — managed with [(values)]", () => {
+  let fixture: ComponentFixture<TwoWayHostComponent>;
+  let inputs: HTMLInputElement[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TwoWayHostComponent] });
+    fixture = TestBed.createComponent(TwoWayHostComponent);
+    fixture.detectChanges();
+    inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="checkbox"]'
+      )
+    ) as HTMLInputElement[];
+  });
+
+  it("should reflect initial values", () => {
+    expect(inputs[0].checked).toBe(true);
+    expect(inputs[1].checked).toBe(false);
+  });
+
+  it("should update bound values on toggle", () => {
+    inputs[1].checked = true;
+    inputs[1].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.selected).toEqual(["a", "b"]);
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [
+    CheckboxGroupComponent,
+    CheckboxComponent,
+    CheckboxCardComponent,
+    CheckboxCardGroupComponent,
+    ReactiveFormsModule,
+  ],
+  template: `
+    <tedi-checkbox-group [formControl]="control">
+      <tedi-checkbox-card-group>
+        <label tedi-checkbox-card variant="primary">
+          <input tedi-checkbox type="checkbox" value="analytics" />
+          Analytics
+        </label>
+        <label tedi-checkbox-card variant="primary">
+          <input tedi-checkbox type="checkbox" value="export" />
+          Export
+        </label>
+      </tedi-checkbox-card-group>
+    </tedi-checkbox-group>
+  `,
+})
+class CardHostComponent {
+  control = new FormControl<string[]>([]);
+}
+
+describe("CheckboxGroupComponent — card children", () => {
+  it("should coordinate card-wrapped checkboxes", () => {
+    TestBed.configureTestingModule({ imports: [CardHostComponent] });
+    const fixture = TestBed.createComponent(CardHostComponent);
+    fixture.detectChanges();
+    const inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="checkbox"]'
+      )
+    ) as HTMLInputElement[];
+    fixture.componentInstance.control.setValue(["export"]);
+    fixture.detectChanges();
+    expect(inputs[0].checked).toBe(false);
+    expect(inputs[1].checked).toBe(true);
+
+    inputs[0].checked = true;
+    inputs[0].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.control.value).toEqual([
+      "export",
+      "analytics",
+    ]);
   });
 });

--- a/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
@@ -206,6 +206,21 @@ class IntrinsicDisabledHostComponent {
   control = new FormControl<string[]>([]);
 }
 
+@Component({
+  standalone: true,
+  imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
+  template: `
+    <tedi-checkbox-group [formControl]="control">
+      <input tedi-checkbox type="checkbox" value="a" [disabled]="aDisabled" />
+      <input tedi-checkbox type="checkbox" value="b" />
+    </tedi-checkbox-group>
+  `,
+})
+class DynamicDisabledHostComponent {
+  control = new FormControl<string[]>([]);
+  aDisabled = false;
+}
+
 describe("CheckboxGroupComponent — per-item disabled", () => {
   it("should preserve intrinsic disabled across group-disabled toggles", () => {
     TestBed.configureTestingModule({
@@ -237,23 +252,8 @@ describe("CheckboxGroupComponent — per-item disabled", () => {
   });
 
   it("should reflect dynamic [disabled] toggles on a child after group-disabled cycles", () => {
-    @Component({
-      standalone: true,
-      imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
-      template: `
-        <tedi-checkbox-group [formControl]="control">
-          <input tedi-checkbox type="checkbox" value="a" [disabled]="aDisabled" />
-          <input tedi-checkbox type="checkbox" value="b" />
-        </tedi-checkbox-group>
-      `,
-    })
-    class DynamicHostComponent {
-      control = new FormControl<string[]>([]);
-      aDisabled = false;
-    }
-
-    TestBed.configureTestingModule({ imports: [DynamicHostComponent] });
-    const fixture = TestBed.createComponent(DynamicHostComponent);
+    TestBed.configureTestingModule({ imports: [DynamicDisabledHostComponent] });
+    const fixture = TestBed.createComponent(DynamicDisabledHostComponent);
     fixture.detectChanges();
     const inputs = Array.from(
       (fixture.nativeElement as HTMLElement).querySelectorAll(
@@ -393,5 +393,46 @@ describe("CheckboxGroupComponent — card children", () => {
       "export",
       "analytics",
     ]);
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
+  template: `
+    <tedi-checkbox-group [formControl]="control">
+      <input tedi-checkbox type="checkbox" />
+    </tedi-checkbox-group>
+  `,
+})
+class MissingValueHostComponent {
+  control = new FormControl<string[]>([]);
+}
+
+describe("CheckboxGroupComponent — missing child value", () => {
+  it("should warn once per instance and drop the change", () => {
+    TestBed.configureTestingModule({ imports: [MissingValueHostComponent] });
+    const fixture = TestBed.createComponent(MissingValueHostComponent);
+    fixture.detectChanges();
+    const input = (
+      fixture.nativeElement as HTMLElement
+    ).querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+
+    input.checked = true;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(fixture.componentInstance.control.value).toEqual([]);
+
+    input.checked = false;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    input.checked = true;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(fixture.componentInstance.control.value).toEqual([]);
+
+    warnSpy.mockRestore();
   });
 });

--- a/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
@@ -147,8 +147,13 @@ describe("CheckboxGroupComponent — managed with FormControl", () => {
     expect(groupElement.getAttribute("role")).toBe("group");
   });
 
-  it("should apply aria-label from label input", () => {
-    expect(groupElement.getAttribute("aria-label")).toBe("Tags");
+  it("should apply aria-labelledby pointing at the rendered label", () => {
+    const labelledBy = groupElement.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    const labelEl = groupElement.querySelector(".tedi-checkbox-group__label");
+    expect(labelEl?.id).toBe(labelledBy);
+    expect(labelEl?.textContent?.trim()).toBe("Tags");
+    expect(groupElement.getAttribute("aria-label")).toBeNull();
   });
 
   it("should reflect FormControl value into native checked state", () => {
@@ -229,6 +234,51 @@ describe("CheckboxGroupComponent — per-item disabled", () => {
     fixture.detectChanges();
     expect(inputs[0].disabled).toBe(false);
     expect(inputs[1].disabled).toBe(true);
+  });
+
+  it("should reflect dynamic [disabled] toggles on a child after group-disabled cycles", () => {
+    @Component({
+      standalone: true,
+      imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
+      template: `
+        <tedi-checkbox-group [formControl]="control">
+          <input tedi-checkbox type="checkbox" value="a" [disabled]="aDisabled" />
+          <input tedi-checkbox type="checkbox" value="b" />
+        </tedi-checkbox-group>
+      `,
+    })
+    class DynamicHostComponent {
+      control = new FormControl<string[]>([]);
+      aDisabled = false;
+    }
+
+    TestBed.configureTestingModule({ imports: [DynamicHostComponent] });
+    const fixture = TestBed.createComponent(DynamicHostComponent);
+    fixture.detectChanges();
+    const inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="checkbox"]'
+      )
+    ) as HTMLInputElement[];
+
+    expect(inputs[0].disabled).toBe(false);
+    fixture.componentInstance.aDisabled = true;
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(true);
+
+    fixture.componentInstance.control.disable();
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(true);
+    expect(inputs[1].disabled).toBe(true);
+
+    fixture.componentInstance.control.enable();
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(true);
+    expect(inputs[1].disabled).toBe(false);
+
+    fixture.componentInstance.aDisabled = false;
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(false);
   });
 
   it("should not update values when intrinsically disabled child fires change", () => {

--- a/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.spec.ts
@@ -112,6 +112,39 @@ describe("CheckboxGroupComponent", () => {
 
 @Component({
   standalone: true,
+  imports: [CheckboxGroupComponent, CheckboxComponent],
+  template: `
+    <tedi-checkbox-group>
+      <input tedi-checkbox type="checkbox" value="a" checked />
+      <input tedi-checkbox type="checkbox" value="b" />
+    </tedi-checkbox-group>
+  `,
+})
+class UnmanagedValuedHostComponent {}
+
+describe("CheckboxGroupComponent — unmanaged with valued children", () => {
+  it("should stay unmanaged and preserve pre-checked state", () => {
+    TestBed.configureTestingModule({ imports: [UnmanagedValuedHostComponent] });
+    const fixture = TestBed.createComponent(UnmanagedValuedHostComponent);
+    fixture.detectChanges();
+    const groupElement = fixture.nativeElement.querySelector(
+      "tedi-checkbox-group"
+    ) as HTMLElement;
+    const inputs = Array.from(
+      groupElement.querySelectorAll('input[type="checkbox"]')
+    ) as HTMLInputElement[];
+
+    expect(groupElement.getAttribute("role")).toBeNull();
+    expect(groupElement.getAttribute("aria-labelledby")).toBeNull();
+    expect(groupElement.getAttribute("aria-label")).toBeNull();
+    expect(groupElement.getAttribute("aria-disabled")).toBeNull();
+    expect(inputs[0].checked).toBe(true);
+    expect(inputs[1].checked).toBe(false);
+  });
+});
+
+@Component({
+  standalone: true,
   imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
   template: `
     <tedi-checkbox-group [formControl]="control" label="Tags">
@@ -189,6 +222,52 @@ describe("CheckboxGroupComponent — managed with FormControl", () => {
     fixture.detectChanges();
     expect(inputs.every((i) => i.disabled)).toBe(true);
     expect(groupElement.getAttribute("aria-disabled")).toBe("true");
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [CheckboxGroupComponent, CheckboxComponent, ReactiveFormsModule],
+  template: `
+    <tedi-checkbox-group
+      [formControl]="control"
+      [ariaLabel]="ariaLabel"
+      [ariaLabelledby]="ariaLabelledby"
+    >
+      <input tedi-checkbox type="checkbox" value="a" />
+    </tedi-checkbox-group>
+  `,
+})
+class AriaNameHostComponent {
+  control = new FormControl<string[]>([]);
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+}
+
+describe("CheckboxGroupComponent — accessible name fallbacks", () => {
+  it("should use ariaLabel when managed and no label/ariaLabelledby", () => {
+    TestBed.configureTestingModule({ imports: [AriaNameHostComponent] });
+    const fixture = TestBed.createComponent(AriaNameHostComponent);
+    fixture.componentInstance.ariaLabel = "My options";
+    fixture.detectChanges();
+    const groupElement = fixture.nativeElement.querySelector(
+      "tedi-checkbox-group"
+    ) as HTMLElement;
+    expect(groupElement.getAttribute("aria-label")).toBe("My options");
+    expect(groupElement.getAttribute("aria-labelledby")).toBeNull();
+  });
+
+  it("should use ariaLabelledby when managed and no label", () => {
+    TestBed.configureTestingModule({ imports: [AriaNameHostComponent] });
+    const fixture = TestBed.createComponent(AriaNameHostComponent);
+    fixture.componentInstance.ariaLabelledby = "external-label";
+    fixture.componentInstance.ariaLabel = "Fallback";
+    fixture.detectChanges();
+    const groupElement = fixture.nativeElement.querySelector(
+      "tedi-checkbox-group"
+    ) as HTMLElement;
+    expect(groupElement.getAttribute("aria-labelledby")).toBe("external-label");
+    expect(groupElement.getAttribute("aria-label")).toBeNull();
   });
 });
 

--- a/tedi/components/form/checkbox-group/checkbox-group.component.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.ts
@@ -103,10 +103,14 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
 
   setDisabledState(isDisabled: boolean): void {
     this.cvaDisabled.set(isDisabled);
+    this.managed.set(true);
   }
 
   registerChild(child: CheckboxComponent): void {
     this.children.update((list) => [...list, child]);
+    if (child.value() !== undefined) {
+      this.managed.set(true);
+    }
     this.applyCheckedTo(child);
   }
 

--- a/tedi/components/form/checkbox-group/checkbox-group.component.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.ts
@@ -18,6 +18,8 @@ import type { CheckboxComponent } from "../checkbox/checkbox.component";
 
 export type CheckboxGroupDirection = "horizontal" | "vertical";
 
+let nextGroupId = 0;
+
 @Component({
   standalone: true,
   imports: [TextComponent],
@@ -36,7 +38,7 @@ export type CheckboxGroupDirection = "horizontal" | "vertical";
   host: {
     class: "tedi-checkbox-group",
     "[attr.role]": "isManaged() ? 'group' : null",
-    "[attr.aria-label]": "isManaged() ? (label() ?? null) : null",
+    "[attr.aria-labelledby]": "isManaged() && label() ? labelId : null",
     "[attr.aria-disabled]": "isManaged() && isDisabled() ? 'true' : null",
   },
 })
@@ -64,11 +66,10 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
   readonly disabled = input<boolean>(false);
 
   private readonly renderer = inject(Renderer2);
+  protected readonly labelId = `tedi-checkbox-group-${++nextGroupId}-label`;
   private readonly children = signal<readonly CheckboxComponent[]>([]);
   private readonly cvaDisabled = signal(false);
   private readonly managed = signal(false);
-  private readonly intrinsicDisabled = new WeakMap<CheckboxComponent, boolean>();
-  private modelSeen = false;
 
   private onChange: (value: string[]) => void = () => {};
   private onTouched: () => void = () => {};
@@ -79,27 +80,10 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
   constructor() {
     effect(() => {
       const v = this.values();
-      if (!this.modelSeen) {
-        this.modelSeen = true;
-        if (v.length > 0) {
-          this.managed.set(true);
-        }
-      } else {
+      if (v.length > 0) {
         this.managed.set(true);
       }
       this.syncChildrenChecked();
-    });
-
-    effect(() => {
-      const groupDisabled = this.isDisabled();
-      for (const child of this.children()) {
-        const intrinsic = this.intrinsicDisabled.get(child) ?? false;
-        this.renderer.setProperty(
-          child.hostElement,
-          "disabled",
-          groupDisabled || intrinsic,
-        );
-      }
     });
   }
 
@@ -122,13 +106,11 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
   }
 
   registerChild(child: CheckboxComponent): void {
-    this.intrinsicDisabled.set(child, child.hostElement.disabled);
     this.children.update((list) => [...list, child]);
     this.applyCheckedTo(child);
   }
 
   unregisterChild(child: CheckboxComponent): void {
-    this.intrinsicDisabled.delete(child);
     this.children.update((list) => list.filter((c) => c !== child));
   }
 

--- a/tedi/components/form/checkbox-group/checkbox-group.component.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.ts
@@ -38,7 +38,8 @@ let nextGroupId = 0;
   host: {
     class: "tedi-checkbox-group",
     "[attr.role]": "isManaged() ? 'group' : null",
-    "[attr.aria-labelledby]": "isManaged() && label() ? labelId : null",
+    "[attr.aria-labelledby]": "managedAriaLabelledby()",
+    "[attr.aria-label]": "managedAriaLabel()",
     "[attr.aria-disabled]": "isManaged() && isDisabled() ? 'true' : null",
   },
 })
@@ -64,6 +65,16 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
    * @default false
    */
   readonly disabled = input<boolean>(false);
+  /**
+   * Accessible name for the group. Use when no visible `label` is rendered.
+   * Ignored when `label` or `ariaLabelledby` is provided.
+   */
+  readonly ariaLabel = input<string>();
+  /**
+   * ID of an external element that labels the group. Ignored when `label` is
+   * provided.
+   */
+  readonly ariaLabelledby = input<string>();
 
   private readonly renderer = inject(Renderer2);
   protected readonly labelId = `tedi-checkbox-group-${++nextGroupId}-label`;
@@ -76,6 +87,16 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
 
   readonly isManaged = this.managed.asReadonly();
   readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
+  protected readonly managedAriaLabelledby = computed<string | null>(() => {
+    if (!this.isManaged()) return null;
+    if (this.label()) return this.labelId;
+    return this.ariaLabelledby() ?? null;
+  });
+  protected readonly managedAriaLabel = computed<string | null>(() => {
+    if (!this.isManaged()) return null;
+    if (this.label() || this.ariaLabelledby()) return null;
+    return this.ariaLabel() ?? null;
+  });
 
   constructor() {
     effect(() => {
@@ -108,9 +129,6 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
 
   registerChild(child: CheckboxComponent): void {
     this.children.update((list) => [...list, child]);
-    if (child.value() !== undefined) {
-      this.managed.set(true);
-    }
     this.applyCheckedTo(child);
   }
 

--- a/tedi/components/form/checkbox-group/checkbox-group.component.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.ts
@@ -1,10 +1,20 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
+  effect,
+  forwardRef,
+  inject,
   input,
+  isDevMode,
+  model,
+  Renderer2,
+  signal,
   ViewEncapsulation,
 } from "@angular/core";
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 import { TextComponent } from "../../base/text/text.component";
+import type { CheckboxComponent } from "../checkbox/checkbox.component";
 
 export type CheckboxGroupDirection = "horizontal" | "vertical";
 
@@ -16,11 +26,21 @@ export type CheckboxGroupDirection = "horizontal" | "vertical";
   styleUrl: "./checkbox-group.component.scss",
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => CheckboxGroupComponent),
+      multi: true,
+    },
+  ],
   host: {
     class: "tedi-checkbox-group",
+    "[attr.role]": "isManaged() ? 'group' : null",
+    "[attr.aria-label]": "isManaged() ? (label() ?? null) : null",
+    "[attr.aria-disabled]": "isManaged() && isDisabled() ? 'true' : null",
   },
 })
-export class CheckboxGroupComponent {
+export class CheckboxGroupComponent implements ControlValueAccessor {
   /**
    * Label text displayed above the checkbox group.
    */
@@ -30,4 +50,131 @@ export class CheckboxGroupComponent {
    * @default horizontal
    */
   readonly direction = input<CheckboxGroupDirection>("horizontal");
+  /**
+   * Selected values. Bind with `[(values)]` or use a FormControl on the group.
+   * When provided, the group enters managed mode and coordinates `checked`
+   * on every registered child.
+   * @default []
+   */
+  readonly values = model<string[]>([]);
+  /**
+   * Disables the entire group. Propagates to all children.
+   * @default false
+   */
+  readonly disabled = input<boolean>(false);
+
+  private readonly renderer = inject(Renderer2);
+  private readonly children = signal<readonly CheckboxComponent[]>([]);
+  private readonly cvaDisabled = signal(false);
+  private readonly managed = signal(false);
+  private readonly intrinsicDisabled = new WeakMap<CheckboxComponent, boolean>();
+  private modelSeen = false;
+
+  private onChange: (value: string[]) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  readonly isManaged = this.managed.asReadonly();
+  readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
+
+  constructor() {
+    effect(() => {
+      const v = this.values();
+      if (!this.modelSeen) {
+        this.modelSeen = true;
+        if (v.length > 0) {
+          this.managed.set(true);
+        }
+      } else {
+        this.managed.set(true);
+      }
+      this.syncChildrenChecked();
+    });
+
+    effect(() => {
+      const groupDisabled = this.isDisabled();
+      for (const child of this.children()) {
+        const intrinsic = this.intrinsicDisabled.get(child) ?? false;
+        this.renderer.setProperty(
+          child.hostElement,
+          "disabled",
+          groupDisabled || intrinsic,
+        );
+      }
+    });
+  }
+
+  writeValue(values: string[] | null): void {
+    this.values.set(values ?? []);
+    this.managed.set(true);
+  }
+
+  registerOnChange(fn: (values: string[]) => void): void {
+    this.onChange = fn;
+    this.managed.set(true);
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.cvaDisabled.set(isDisabled);
+  }
+
+  registerChild(child: CheckboxComponent): void {
+    this.intrinsicDisabled.set(child, child.hostElement.disabled);
+    this.children.update((list) => [...list, child]);
+    this.applyCheckedTo(child);
+  }
+
+  unregisterChild(child: CheckboxComponent): void {
+    this.intrinsicDisabled.delete(child);
+    this.children.update((list) => list.filter((c) => c !== child));
+  }
+
+  onChildChange(value: string, checked: boolean): void {
+    if (!this.isManaged()) return;
+    const current = this.values();
+    const has = current.includes(value);
+    if (checked && !has) {
+      this.values.set([...current, value]);
+    } else if (!checked && has) {
+      this.values.set(current.filter((v) => v !== value));
+    } else {
+      return;
+    }
+    this.onChange(this.values());
+    this.onTouched();
+  }
+
+  isSelected(value: string | undefined): boolean {
+    return value !== undefined && this.values().includes(value);
+  }
+
+  private syncChildrenChecked(): void {
+    if (!this.isManaged()) return;
+    for (const child of this.children()) {
+      this.applyCheckedTo(child);
+    }
+  }
+
+  private applyCheckedTo(child: CheckboxComponent): void {
+    if (!this.isManaged()) return;
+    const v = child.value();
+    if (v === undefined) return;
+    const desired = this.values().includes(v);
+    const el = child.hostElement;
+    if (el.checked !== desired) {
+      this.renderer.setProperty(el, "checked", desired);
+    }
+  }
+
+  /** @internal */
+  warnMissingValue(): void {
+    if (isDevMode()) {
+      console.warn(
+        "[tedi-checkbox-group] A checkbox inside a managed group is missing a [value] input and will be ignored.",
+      );
+    }
+  }
 }

--- a/tedi/components/form/checkbox-group/checkbox-group.component.ts
+++ b/tedi/components/form/checkbox-group/checkbox-group.component.ts
@@ -82,8 +82,8 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
   private readonly cvaDisabled = signal(false);
   private readonly managed = signal(false);
 
-  private onChange: (value: string[]) => void = () => {};
-  private onTouched: () => void = () => {};
+  private onChange: (value: string[]) => void = () => { };
+  private onTouched: () => void = () => { };
 
   readonly isManaged = this.managed.asReadonly();
   readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
@@ -100,8 +100,7 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
 
   constructor() {
     effect(() => {
-      const v = this.values();
-      if (v.length > 0) {
+      if (this.values().length > 0) {
         this.managed.set(true);
       }
       this.syncChildrenChecked();
@@ -164,9 +163,9 @@ export class CheckboxGroupComponent implements ControlValueAccessor {
 
   private applyCheckedTo(child: CheckboxComponent): void {
     if (!this.isManaged()) return;
-    const v = child.value();
-    if (v === undefined) return;
-    const desired = this.values().includes(v);
+    const childVal = child.value();
+    if (childVal === undefined) return;
+    const desired = this.values().includes(childVal);
     const el = child.hostElement;
     if (el.checked !== desired) {
       this.renderer.setProperty(el, "checked", desired);

--- a/tedi/components/form/checkbox/checkbox.component.scss
+++ b/tedi/components/form/checkbox/checkbox.component.scss
@@ -76,9 +76,8 @@ input[tedi-checkbox][type="checkbox"] {
   }
 
   &:focus-visible {
-    outline-width: 2px;
-    outline-style: solid;
-    outline-offset: 2px;
+    outline: var(--tedi-borders-02) solid var(--tedi-primary-500);
+    outline-offset: var(--tedi-borders-01);
   }
 
   &:not(:checked, :disabled).tedi-checkbox--invalid,

--- a/tedi/components/form/checkbox/checkbox.component.scss
+++ b/tedi/components/form/checkbox/checkbox.component.scss
@@ -5,6 +5,7 @@ input[tedi-checkbox][type="checkbox"] {
 
   position: relative;
   width: var(--form-checkbox-radio-size-responsive);
+  min-width: var(--form-checkbox-radio-size-responsive);
   height: var(--form-checkbox-radio-size-responsive);
   padding: 0;
   margin: 0;
@@ -43,9 +44,7 @@ input[tedi-checkbox][type="checkbox"] {
 
     &:disabled {
       cursor: not-allowed;
-      background-color: var(
-        --form-checkbox-radio-default-background-selected-disabled
-      );
+      background-color: var(--form-checkbox-radio-default-background-selected-disabled);
       border-color: var(--form-checkbox-radio-default-border-selected-disabled);
     }
 
@@ -108,7 +107,7 @@ label:has(input[tedi-checkbox]:disabled) {
   cursor: not-allowed;
 }
 
-label:has(input[tedi-checkbox]) + tedi-feedback-text {
+label:has(input[tedi-checkbox])+tedi-feedback-text {
   padding-left: var(--form-checkbox-radio-size-responsive);
   margin-left: var(--form-checkbox-radio-inner-spacing);
 }

--- a/tedi/components/form/checkbox/checkbox.component.scss
+++ b/tedi/components/form/checkbox/checkbox.component.scss
@@ -81,12 +81,14 @@ input[tedi-checkbox][type="checkbox"] {
   }
 
   &:not(:checked, :disabled).tedi-checkbox--invalid,
-  &:user-invalid,
-  &.ng-invalid.ng-touched {
+  &:not(:checked, :disabled):user-invalid,
+  &:not(:checked, :disabled).ng-invalid.ng-touched {
+    background-color: var(--form-checkbox-radio-default-background-error);
     border-color: var(--form-general-feedback-error-border);
 
     &:hover {
-      border-color: var(--form-checkbox-radio-default-border-hover);
+      border-color: var(--form-general-feedback-error-border);
+      box-shadow: 0 0 0 1px var(--form-general-feedback-error-border);
     }
   }
 
@@ -96,6 +98,14 @@ input[tedi-checkbox][type="checkbox"] {
     width: var(--form-checkbox-radio-size-large);
     height: var(--form-checkbox-radio-size-large);
   }
+}
+
+label:has(input[tedi-checkbox]:not(:disabled)) {
+  cursor: pointer;
+}
+
+label:has(input[tedi-checkbox]:disabled) {
+  cursor: not-allowed;
 }
 
 label:has(input[tedi-checkbox]) + tedi-feedback-text {

--- a/tedi/components/form/checkbox/checkbox.component.ts
+++ b/tedi/components/form/checkbox/checkbox.component.ts
@@ -1,9 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
+  inject,
   input,
+  OnDestroy,
+  OnInit,
   ViewEncapsulation,
 } from "@angular/core";
+import { CheckboxGroupComponent } from "../checkbox-group/checkbox-group.component";
 
 export type CheckboxSize = "default" | "large";
 
@@ -17,9 +22,10 @@ export type CheckboxSize = "default" | "large";
   host: {
     "[class.tedi-checkbox--large]": "size() === 'large'",
     "[class.tedi-checkbox--invalid]": "invalid()",
+    "(change)": "handleChange()",
   },
 })
-export class CheckboxComponent {
+export class CheckboxComponent implements OnInit, OnDestroy {
   /**
    * Size of the checkbox.
    * @default default
@@ -30,4 +36,41 @@ export class CheckboxComponent {
    * @default false
    */
   readonly invalid = input(false);
+  /**
+   * Identity of this checkbox inside a managed `<tedi-checkbox-group>`.
+   * Required when the parent group is managed (has a FormControl or
+   * `[(values)]` binding). Ignored otherwise.
+   */
+  readonly value = input<string>();
+
+  private readonly elementRef =
+    inject<ElementRef<HTMLInputElement>>(ElementRef);
+  private readonly group = inject(CheckboxGroupComponent, { optional: true });
+  private warned = false;
+
+  get hostElement(): HTMLInputElement {
+    return this.elementRef.nativeElement;
+  }
+
+  ngOnInit(): void {
+    this.group?.registerChild(this);
+  }
+
+  ngOnDestroy(): void {
+    this.group?.unregisterChild(this);
+  }
+
+  handleChange(): void {
+    if (!this.group || !this.group.isManaged()) return;
+    if (this.hostElement.disabled) return;
+    const v = this.value();
+    if (v === undefined) {
+      if (!this.warned) {
+        this.warned = true;
+        this.group.warnMissingValue();
+      }
+      return;
+    }
+    this.group.onChildChange(v, this.hostElement.checked);
+  }
 }

--- a/tedi/components/form/checkbox/checkbox.component.ts
+++ b/tedi/components/form/checkbox/checkbox.component.ts
@@ -1,6 +1,8 @@
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  computed,
   ElementRef,
   inject,
   input,
@@ -22,6 +24,7 @@ export type CheckboxSize = "default" | "large";
   host: {
     "[class.tedi-checkbox--large]": "size() === 'large'",
     "[class.tedi-checkbox--invalid]": "invalid()",
+    "[disabled]": "effectiveDisabled()",
     "(change)": "handleChange()",
   },
 })
@@ -42,11 +45,21 @@ export class CheckboxComponent implements OnInit, OnDestroy {
    * `[(values)]` binding). Ignored otherwise.
    */
   readonly value = input<string>();
+  /**
+   * Disables this checkbox. An enclosing disabled `<tedi-checkbox-group>`
+   * forces disabled regardless of this input.
+   * @default false
+   */
+  readonly disabled = input(false, { transform: booleanAttribute });
 
   private readonly elementRef =
     inject<ElementRef<HTMLInputElement>>(ElementRef);
   private readonly group = inject(CheckboxGroupComponent, { optional: true });
   private warned = false;
+
+  readonly effectiveDisabled = computed(
+    () => this.disabled() || (this.group?.isDisabled() ?? false),
+  );
 
   get hostElement(): HTMLInputElement {
     return this.elementRef.nativeElement;
@@ -62,7 +75,7 @@ export class CheckboxComponent implements OnInit, OnDestroy {
 
   handleChange(): void {
     if (!this.group || !this.group.isManaged()) return;
-    if (this.hostElement.disabled) return;
+    if (this.effectiveDisabled()) return;
     const v = this.value();
     if (v === undefined) {
       if (!this.warned) {

--- a/tedi/components/form/checkbox/checkbox.stories.ts
+++ b/tedi/components/form/checkbox/checkbox.stories.ts
@@ -4,6 +4,7 @@ import {
   moduleMetadata,
   StoryObj,
 } from "@storybook/angular";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { CheckboxComponent } from "./checkbox.component";
 import { CheckboxCardComponent } from "../checkbox-card/checkbox-card.component";
 import { CheckboxGroupComponent } from "../checkbox-group/checkbox-group.component";
@@ -18,6 +19,7 @@ import { TooltipTriggerComponent } from "../../overlay/tooltip/tooltip-trigger/t
 import { TooltipContentComponent } from "../../overlay/tooltip/tooltip-content/tooltip-content.component";
 import { InfoButtonComponent } from "../../buttons/info-button/info-button.component";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
+import { AlertComponent } from "../../notifications/alert/alert.component";
 
 type StoryCheckboxComponent = CheckboxComponent & {
   indeterminate: boolean;
@@ -47,6 +49,8 @@ export default {
         TooltipContentComponent,
         InfoButtonComponent,
         FeedbackTextComponent,
+        AlertComponent,
+        ReactiveFormsModule,
       ],
     }),
   ],
@@ -812,4 +816,115 @@ export const CheckboxCardStates: StoryObj<CheckboxComponent> = {
       </tedi-row>
     `,
   }),
+};
+
+/**
+ * The group supports two form-binding modes:
+ *
+ * - **Group-level**: bind `[formControl]` to `<tedi-checkbox-group>`. The group
+ *   coordinates `checked` and `disabled` across children. Emits the selected
+ *   values as `string[]` on a single control.
+ * - **Individual-level (Angular native)**: bind `[formControl]` to each
+ *   `<input type="checkbox">` using Angular's built-in
+ *   `CheckboxControlValueAccessor`. Each control holds a boolean.
+ */
+export const WithReactiveForms: StoryObj<CheckboxComponent> = {
+  render: () => {
+    const tagsControl = new FormControl<string[]>(["urgent"]);
+    const featuresControl = new FormControl<string[]>([
+      "analytics",
+      "export",
+    ]);
+    const readControl = new FormControl<boolean>(true);
+    const writeControl = new FormControl<boolean>(false);
+    const adminControl = new FormControl<boolean>(false);
+
+    return {
+      props: {
+        tagsControl,
+        featuresControl,
+        readControl,
+        writeControl,
+        adminControl,
+      },
+      template: `
+        <tedi-row cols="1" [gapY]="3">
+          <tedi-col>
+            <tedi-checkbox-group label="Tags" [formControl]="tagsControl">
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-checkbox type="checkbox" value="urgent" />
+                Urgent
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-checkbox type="checkbox" value="review" />
+                Review
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-checkbox type="checkbox" value="draft" disabled />
+                Draft
+              </label>
+            </tedi-checkbox-group>
+          </tedi-col>
+
+          <tedi-col>
+            <tedi-checkbox-group label="Features" [formControl]="featuresControl">
+              <tedi-checkbox-card-group>
+                <label tedi-checkbox-card variant="primary">
+                  <input tedi-checkbox type="checkbox" value="analytics" />
+                  Analytics
+                </label>
+                <label tedi-checkbox-card variant="primary">
+                  <input tedi-checkbox type="checkbox" value="export" />
+                  Export
+                </label>
+                <label tedi-checkbox-card variant="primary">
+                  <input tedi-checkbox type="checkbox" value="audit-log" />
+                  Audit log
+                </label>
+              </tedi-checkbox-card-group>
+            </tedi-checkbox-group>
+          </tedi-col>
+
+          <tedi-col>
+            <tedi-checkbox-group label="Permissions">
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-checkbox type="checkbox" [formControl]="readControl" />
+                Read
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-checkbox type="checkbox" [formControl]="writeControl" />
+                Write
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-checkbox type="checkbox" [formControl]="adminControl" />
+                Admin
+              </label>
+            </tedi-checkbox-group>
+          </tedi-col>
+
+          <tedi-col>
+            <tedi-alert type="info" [showClose]="false">
+              <pre tedi-text modifiers="small">{{ {
+  tags: {
+    value: tagsControl.value,
+    touched: tagsControl.touched,
+    dirty: tagsControl.dirty
+  },
+  features: {
+    value: featuresControl.value,
+    touched: featuresControl.touched,
+    dirty: featuresControl.dirty
+  },
+  permissions: {
+    read: readControl.value,
+    write: writeControl.value,
+    admin: adminControl.value
+  }
+} | json }}</pre>
+            </tedi-alert>
+          </tedi-col>
+        </tedi-row>
+      `,
+    };
+  },
 };

--- a/tedi/components/form/checkbox/checkbox.stories.ts
+++ b/tedi/components/form/checkbox/checkbox.stories.ts
@@ -437,6 +437,7 @@ export const States: StoryObj<CheckboxComponent> = {
     pseudo: {
       hover: "#Hover",
       active: "#Active",
+      focusVisible: "#Focus",
     },
   },
   render: (args) => ({
@@ -464,6 +465,12 @@ export const States: StoryObj<CheckboxComponent> = {
         <strong>Active</strong>
         <label tedi-label color="primary" class="flex align-items-center gap-2">
           <input tedi-checkbox type="checkbox" checked id="Active" />
+          Text
+        </label>
+
+        <strong>Focus</strong>
+        <label tedi-label color="primary" class="flex align-items-center gap-2">
+          <input tedi-checkbox type="checkbox" id="Focus" />
           Text
         </label>
 

--- a/tedi/components/form/radio-card-group/radio-card-group.component.scss
+++ b/tedi/components/form/radio-card-group/radio-card-group.component.scss
@@ -2,4 +2,10 @@
   display: flex;
   flex-wrap: wrap;
   gap: var(--form-checkbox-radio-card-gutter);
+
+  &--grouped {
+    display: inline-flex;
+    flex-wrap: nowrap;
+    gap: 0;
+  }
 }

--- a/tedi/components/form/radio-card-group/radio-card-group.component.spec.ts
+++ b/tedi/components/form/radio-card-group/radio-card-group.component.spec.ts
@@ -8,7 +8,7 @@ import { RadioComponent } from "../radio/radio.component";
   standalone: true,
   imports: [RadioCardGroupComponent, RadioCardComponent, RadioComponent],
   template: `
-    <tedi-radio-card-group>
+    <tedi-radio-card-group [grouped]="grouped">
       <label tedi-radio-card variant="primary">
         <input tedi-radio type="radio" name="test" />
         Option 1
@@ -20,7 +20,9 @@ import { RadioComponent } from "../radio/radio.component";
     </tedi-radio-card-group>
   `,
 })
-class TestHostComponent {}
+class TestHostComponent {
+  grouped = false;
+}
 
 describe("RadioCardGroupComponent", () => {
   let fixture: ComponentFixture<TestHostComponent>;
@@ -46,5 +48,40 @@ describe("RadioCardGroupComponent", () => {
   it("should project card content", () => {
     const cards = groupElement.querySelectorAll("label[tedi-radio-card]");
     expect(cards.length).toBe(2);
+  });
+
+  it("should not have grouped class by default", () => {
+    expect(groupElement.classList).not.toContain(
+      "tedi-radio-card-group--grouped"
+    );
+  });
+
+  it("should apply grouped class when grouped input is true", () => {
+    fixture.componentInstance.grouped = true;
+    fixture.detectChanges();
+    expect(groupElement.classList).toContain(
+      "tedi-radio-card-group--grouped"
+    );
+  });
+
+  it("should propagate grouped state to child cards", () => {
+    fixture.componentInstance.grouped = true;
+    fixture.detectChanges();
+    const cards = Array.from(
+      groupElement.querySelectorAll("label[tedi-radio-card]")
+    );
+    expect(cards.length).toBe(2);
+    for (const card of cards) {
+      expect(card.classList).toContain("tedi-radio-card--grouped");
+    }
+  });
+
+  it("should not apply grouped class to children when group is not grouped", () => {
+    const cards = Array.from(
+      groupElement.querySelectorAll("label[tedi-radio-card]")
+    );
+    for (const card of cards) {
+      expect(card.classList).not.toContain("tedi-radio-card--grouped");
+    }
   });
 });

--- a/tedi/components/form/radio-card-group/radio-card-group.component.ts
+++ b/tedi/components/form/radio-card-group/radio-card-group.component.ts
@@ -1,6 +1,7 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  input,
   ViewEncapsulation,
 } from "@angular/core";
 
@@ -13,6 +14,15 @@ import {
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
     class: "tedi-radio-card-group",
+    "[class.tedi-radio-card-group--grouped]": "grouped()",
   },
 })
-export class RadioCardGroupComponent {}
+export class RadioCardGroupComponent {
+  /**
+   * Renders children in a button-group style layout with shared borders and
+   * no gap. Child `tedi-radio-card` instances automatically inherit this and
+   * do not need their own `grouped` input.
+   * @default false
+   */
+  readonly grouped = input<boolean>(false);
+}

--- a/tedi/components/form/radio-card/radio-card.component.scss
+++ b/tedi/components/form/radio-card/radio-card.component.scss
@@ -72,8 +72,8 @@ label[tedi-radio-card] {
   }
 
   &:has(input:focus-visible) {
-    outline: 2px solid var(--form-input-border-active);
-    outline-offset: 1px;
+    outline: var(--tedi-borders-02) solid var(--tedi-primary-500);
+    outline-offset: var(--tedi-borders-01);
 
     input[tedi-radio]:focus-visible {
       outline: none;
@@ -204,7 +204,7 @@ label[tedi-radio-card] {
       --_card-text: var(--form-checkbox-radio-card-secondary-selected-text);
       --_card-border: var(--form-checkbox-radio-card-secondary-selected-border);
 
-      box-shadow: inset 0 0 0 1px var(--_card-border);
+      box-shadow: inset 0 0 0 var(--tedi-borders-01) var(--_card-border);
     }
 
     &:has(input:hover:not(:disabled)) {
@@ -236,7 +236,7 @@ label[tedi-radio-card] {
         --form-checkbox-radio-card-secondary-disabled-selected-border
       );
 
-      box-shadow: inset 0 0 0 1px var(--_card-border);
+      box-shadow: inset 0 0 0 var(--tedi-borders-01) var(--_card-border);
     }
   }
 }

--- a/tedi/components/form/radio-card/radio-card.component.spec.ts
+++ b/tedi/components/form/radio-card/radio-card.component.spec.ts
@@ -4,6 +4,7 @@ import {
   RadioCardComponent,
   RadioCardVariant,
 } from "./radio-card.component";
+import { RadioCardGroupComponent } from "../radio-card-group/radio-card-group.component";
 import { RadioComponent } from "../radio/radio.component";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
 
@@ -104,5 +105,50 @@ describe("RadioCardComponent", () => {
     expect(labelElement.classList).toContain(
       "tedi-radio-card--hide-indicator"
     );
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [RadioCardComponent, RadioCardGroupComponent, RadioComponent],
+  template: `
+    <tedi-radio-card-group [grouped]="groupGrouped">
+      <label tedi-radio-card [grouped]="cardGrouped">
+        <input tedi-radio type="radio" name="inherit-test" />
+        Option
+      </label>
+    </tedi-radio-card-group>
+  `,
+})
+class InheritanceHostComponent {
+  groupGrouped = false;
+  cardGrouped = false;
+}
+
+describe("RadioCardComponent — grouped inheritance", () => {
+  let fixture: ComponentFixture<InheritanceHostComponent>;
+  let labelElement: HTMLLabelElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [InheritanceHostComponent] });
+    fixture = TestBed.createComponent(InheritanceHostComponent);
+    fixture.detectChanges();
+    labelElement = fixture.nativeElement.querySelector("label[tedi-radio-card]");
+  });
+
+  it("should not be grouped when neither input is set", () => {
+    expect(labelElement.classList).not.toContain("tedi-radio-card--grouped");
+  });
+
+  it("should be grouped when parent group is grouped", () => {
+    fixture.componentInstance.groupGrouped = true;
+    fixture.detectChanges();
+    expect(labelElement.classList).toContain("tedi-radio-card--grouped");
+  });
+
+  it("should be grouped when card's own input is set", () => {
+    fixture.componentInstance.cardGrouped = true;
+    fixture.detectChanges();
+    expect(labelElement.classList).toContain("tedi-radio-card--grouped");
   });
 });

--- a/tedi/components/form/radio-card/radio-card.component.ts
+++ b/tedi/components/form/radio-card/radio-card.component.ts
@@ -1,9 +1,12 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
+  inject,
   input,
   ViewEncapsulation,
 } from "@angular/core";
+import { RadioCardGroupComponent } from "../radio-card-group/radio-card-group.component";
 
 export type RadioCardVariant = "primary" | "secondary";
 
@@ -18,7 +21,7 @@ export type RadioCardVariant = "primary" | "secondary";
     class: "tedi-radio-card",
     "[class.tedi-radio-card--primary]": "variant() === 'primary'",
     "[class.tedi-radio-card--secondary]": "variant() === 'secondary'",
-    "[class.tedi-radio-card--grouped]": "grouped()",
+    "[class.tedi-radio-card--grouped]": "isGrouped()",
     "[class.tedi-radio-card--hide-indicator]": "!showIndicator()",
   },
 })
@@ -29,7 +32,9 @@ export class RadioCardComponent {
    */
   readonly variant = input<RadioCardVariant>("primary");
   /**
-   * Whether the card is part of a button-group style layout.
+   * Whether the card is part of a button-group style layout. Prefer setting
+   * `grouped` on the enclosing `tedi-radio-card-group` instead; this input
+   * is retained for standalone cards outside a group.
    * @default false
    */
   readonly grouped = input(false);
@@ -40,4 +45,12 @@ export class RadioCardComponent {
    * @default true
    */
   readonly showIndicator = input<boolean>(true);
+
+  private readonly cardGroup = inject(RadioCardGroupComponent, {
+    optional: true,
+  });
+
+  readonly isGrouped = computed(
+    () => this.grouped() || (this.cardGroup?.grouped() ?? false),
+  );
 }

--- a/tedi/components/form/radio-card/radio-card.component.ts
+++ b/tedi/components/form/radio-card/radio-card.component.ts
@@ -35,6 +35,10 @@ export class RadioCardComponent {
    * Whether the card is part of a button-group style layout. Prefer setting
    * `grouped` on the enclosing `tedi-radio-card-group` instead; this input
    * is retained for standalone cards outside a group.
+   *
+   * The effective state is `grouped || parentGrouped` (see `isGrouped()` and
+   * `RadioCardGroupComponent`): a child cannot opt out when its parent is
+   * grouped.
    * @default false
    */
   readonly grouped = input(false);

--- a/tedi/components/form/radio-group/radio-group.component.html
+++ b/tedi/components/form/radio-group/radio-group.component.html
@@ -1,5 +1,5 @@
 @if (label()) {
-  <p class="tedi-radio-group__label" tedi-text color="secondary">{{ label() }}</p>
+  <p [id]="labelId" class="tedi-radio-group__label" tedi-text color="secondary">{{ label() }}</p>
 }
 <div class="tedi-radio-group__checks" [class.tedi-radio-group__checks--vertical]="direction() === 'vertical'">
   <ng-content />

--- a/tedi/components/form/radio-group/radio-group.component.spec.ts
+++ b/tedi/components/form/radio-group/radio-group.component.spec.ts
@@ -228,6 +228,40 @@ describe("RadioGroupComponent — managed with [(value)]", () => {
 
 @Component({
   standalone: true,
+  imports: [RadioGroupComponent, RadioComponent],
+  template: `
+    <tedi-radio-group [(value)]="selected">
+      <input tedi-radio type="radio" value="a" />
+      <input tedi-radio type="radio" value="b" />
+    </tedi-radio-group>
+  `,
+})
+class TwoWayNullInitialHostComponent {
+  selected: string | null = null;
+}
+
+describe("RadioGroupComponent — managed with [(value)] starting null", () => {
+  it("should propagate clicks even when two-way value starts null", () => {
+    TestBed.configureTestingModule({
+      imports: [TwoWayNullInitialHostComponent],
+    });
+    const fixture = TestBed.createComponent(TwoWayNullInitialHostComponent);
+    fixture.detectChanges();
+    const inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="radio"]'
+      )
+    ) as HTMLInputElement[];
+
+    inputs[1].checked = true;
+    inputs[1].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.selected).toBe("b");
+  });
+});
+
+@Component({
+  standalone: true,
   imports: [
     RadioGroupComponent,
     RadioComponent,

--- a/tedi/components/form/radio-group/radio-group.component.spec.ts
+++ b/tedi/components/form/radio-group/radio-group.component.spec.ts
@@ -110,6 +110,41 @@ describe("RadioGroupComponent", () => {
 
 @Component({
   standalone: true,
+  imports: [RadioGroupComponent, RadioComponent],
+  template: `
+    <tedi-radio-group>
+      <input tedi-radio type="radio" value="a" name="static" checked />
+      <input tedi-radio type="radio" value="b" name="static" />
+    </tedi-radio-group>
+  `,
+})
+class UnmanagedValuedHostComponent {}
+
+describe("RadioGroupComponent — unmanaged with valued children", () => {
+  it("should stay unmanaged and preserve names and pre-checked state", () => {
+    TestBed.configureTestingModule({ imports: [UnmanagedValuedHostComponent] });
+    const fixture = TestBed.createComponent(UnmanagedValuedHostComponent);
+    fixture.detectChanges();
+    const groupElement = fixture.nativeElement.querySelector(
+      "tedi-radio-group"
+    ) as HTMLElement;
+    const inputs = Array.from(
+      groupElement.querySelectorAll('input[type="radio"]')
+    ) as HTMLInputElement[];
+
+    expect(groupElement.getAttribute("role")).toBeNull();
+    expect(groupElement.getAttribute("aria-labelledby")).toBeNull();
+    expect(groupElement.getAttribute("aria-label")).toBeNull();
+    expect(groupElement.getAttribute("aria-disabled")).toBeNull();
+    expect(inputs[0].getAttribute("name")).toBe("static");
+    expect(inputs[1].getAttribute("name")).toBe("static");
+    expect(inputs[0].checked).toBe(true);
+    expect(inputs[1].checked).toBe(false);
+  });
+});
+
+@Component({
+  standalone: true,
   imports: [RadioGroupComponent, RadioComponent, ReactiveFormsModule],
   template: `
     <tedi-radio-group [formControl]="control" label="Status">
@@ -186,6 +221,52 @@ describe("RadioGroupComponent — managed with FormControl", () => {
 
 @Component({
   standalone: true,
+  imports: [RadioGroupComponent, RadioComponent, ReactiveFormsModule],
+  template: `
+    <tedi-radio-group
+      [formControl]="control"
+      [ariaLabel]="ariaLabel"
+      [ariaLabelledby]="ariaLabelledby"
+    >
+      <input tedi-radio type="radio" value="a" />
+    </tedi-radio-group>
+  `,
+})
+class AriaNameHostComponent {
+  control = new FormControl<string | null>(null);
+  ariaLabel?: string;
+  ariaLabelledby?: string;
+}
+
+describe("RadioGroupComponent — accessible name fallbacks", () => {
+  it("should use ariaLabel when managed and no label/ariaLabelledby", () => {
+    TestBed.configureTestingModule({ imports: [AriaNameHostComponent] });
+    const fixture = TestBed.createComponent(AriaNameHostComponent);
+    fixture.componentInstance.ariaLabel = "My options";
+    fixture.detectChanges();
+    const groupElement = fixture.nativeElement.querySelector(
+      "tedi-radio-group"
+    ) as HTMLElement;
+    expect(groupElement.getAttribute("aria-label")).toBe("My options");
+    expect(groupElement.getAttribute("aria-labelledby")).toBeNull();
+  });
+
+  it("should use ariaLabelledby when managed and no label", () => {
+    TestBed.configureTestingModule({ imports: [AriaNameHostComponent] });
+    const fixture = TestBed.createComponent(AriaNameHostComponent);
+    fixture.componentInstance.ariaLabelledby = "external-label";
+    fixture.componentInstance.ariaLabel = "Fallback";
+    fixture.detectChanges();
+    const groupElement = fixture.nativeElement.querySelector(
+      "tedi-radio-group"
+    ) as HTMLElement;
+    expect(groupElement.getAttribute("aria-labelledby")).toBe("external-label");
+    expect(groupElement.getAttribute("aria-label")).toBeNull();
+  });
+});
+
+@Component({
+  standalone: true,
   imports: [RadioGroupComponent, RadioComponent],
   template: `
     <tedi-radio-group [(value)]="selected">
@@ -219,40 +300,6 @@ describe("RadioGroupComponent — managed with [(value)]", () => {
   });
 
   it("should update bound value on click", () => {
-    inputs[1].checked = true;
-    inputs[1].dispatchEvent(new Event("change", { bubbles: true }));
-    fixture.detectChanges();
-    expect(fixture.componentInstance.selected).toBe("b");
-  });
-});
-
-@Component({
-  standalone: true,
-  imports: [RadioGroupComponent, RadioComponent],
-  template: `
-    <tedi-radio-group [(value)]="selected">
-      <input tedi-radio type="radio" value="a" />
-      <input tedi-radio type="radio" value="b" />
-    </tedi-radio-group>
-  `,
-})
-class TwoWayNullInitialHostComponent {
-  selected: string | null = null;
-}
-
-describe("RadioGroupComponent — managed with [(value)] starting null", () => {
-  it("should propagate clicks even when two-way value starts null", () => {
-    TestBed.configureTestingModule({
-      imports: [TwoWayNullInitialHostComponent],
-    });
-    const fixture = TestBed.createComponent(TwoWayNullInitialHostComponent);
-    fixture.detectChanges();
-    const inputs = Array.from(
-      (fixture.nativeElement as HTMLElement).querySelectorAll(
-        'input[type="radio"]'
-      )
-    ) as HTMLInputElement[];
-
     inputs[1].checked = true;
     inputs[1].dispatchEvent(new Event("change", { bubbles: true }));
     fixture.detectChanges();

--- a/tedi/components/form/radio-group/radio-group.component.spec.ts
+++ b/tedi/components/form/radio-group/radio-group.component.spec.ts
@@ -145,8 +145,13 @@ describe("RadioGroupComponent — managed with FormControl", () => {
     expect(groupElement.getAttribute("role")).toBe("radiogroup");
   });
 
-  it("should apply aria-label from label input", () => {
-    expect(groupElement.getAttribute("aria-label")).toBe("Status");
+  it("should apply aria-labelledby pointing at the rendered label", () => {
+    const labelledBy = groupElement.getAttribute("aria-labelledby");
+    expect(labelledBy).toBeTruthy();
+    const labelEl = groupElement.querySelector(".tedi-radio-group__label");
+    expect(labelEl?.id).toBe(labelledBy);
+    expect(labelEl?.textContent?.trim()).toBe("Status");
+    expect(groupElement.getAttribute("aria-label")).toBeNull();
   });
 
   it("should share an auto-generated name across children", () => {
@@ -248,6 +253,53 @@ describe("RadioGroupComponent — managed with [(value)]", () => {
 class CardHostComponent {
   control = new FormControl<string | null>(null);
 }
+
+describe("RadioGroupComponent — per-item disabled", () => {
+  it("should reflect dynamic [disabled] toggles on a child after group-disabled cycles", () => {
+    @Component({
+      standalone: true,
+      imports: [RadioGroupComponent, RadioComponent, ReactiveFormsModule],
+      template: `
+        <tedi-radio-group [formControl]="control">
+          <input tedi-radio type="radio" value="a" [disabled]="aDisabled" />
+          <input tedi-radio type="radio" value="b" />
+        </tedi-radio-group>
+      `,
+    })
+    class DynamicHostComponent {
+      control = new FormControl<string | null>(null);
+      aDisabled = false;
+    }
+
+    TestBed.configureTestingModule({ imports: [DynamicHostComponent] });
+    const fixture = TestBed.createComponent(DynamicHostComponent);
+    fixture.detectChanges();
+    const inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="radio"]'
+      )
+    ) as HTMLInputElement[];
+
+    expect(inputs[0].disabled).toBe(false);
+    fixture.componentInstance.aDisabled = true;
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(true);
+
+    fixture.componentInstance.control.disable();
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(true);
+    expect(inputs[1].disabled).toBe(true);
+
+    fixture.componentInstance.control.enable();
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(true);
+    expect(inputs[1].disabled).toBe(false);
+
+    fixture.componentInstance.aDisabled = false;
+    fixture.detectChanges();
+    expect(inputs[0].disabled).toBe(false);
+  });
+});
 
 describe("RadioGroupComponent — card children", () => {
   it("should coordinate card-wrapped radios", () => {

--- a/tedi/components/form/radio-group/radio-group.component.spec.ts
+++ b/tedi/components/form/radio-group/radio-group.component.spec.ts
@@ -1,10 +1,13 @@
 import { Component } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import {
   RadioGroupComponent,
   RadioGroupDirection,
 } from "./radio-group.component";
 import { RadioComponent } from "../radio/radio.component";
+import { RadioCardComponent } from "../radio-card/radio-card.component";
+import { RadioCardGroupComponent } from "../radio-card-group/radio-card-group.component";
 import { LabelComponent } from "../label/label.component";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
 
@@ -98,5 +101,172 @@ describe("RadioGroupComponent", () => {
     );
     const feedbackText = subtexts?.querySelector("tedi-feedback-text");
     expect(feedbackText).toBeTruthy();
+  });
+
+  it("should not set role when unmanaged (back-compat)", () => {
+    expect(groupElement.getAttribute("role")).toBeNull();
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [RadioGroupComponent, RadioComponent, ReactiveFormsModule],
+  template: `
+    <tedi-radio-group [formControl]="control" label="Status">
+      <input tedi-radio type="radio" value="all" />
+      <input tedi-radio type="radio" value="active" />
+      <input tedi-radio type="radio" value="done" />
+    </tedi-radio-group>
+  `,
+})
+class FormControlHostComponent {
+  control = new FormControl<string | null>(null);
+}
+
+describe("RadioGroupComponent — managed with FormControl", () => {
+  let fixture: ComponentFixture<FormControlHostComponent>;
+  let groupElement: HTMLElement;
+  let inputs: HTMLInputElement[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [FormControlHostComponent],
+    });
+
+    fixture = TestBed.createComponent(FormControlHostComponent);
+    fixture.detectChanges();
+    groupElement = fixture.nativeElement.querySelector("tedi-radio-group");
+    inputs = Array.from(
+      groupElement.querySelectorAll('input[type="radio"]')
+    ) as HTMLInputElement[];
+  });
+
+  it("should apply role=radiogroup when managed", () => {
+    expect(groupElement.getAttribute("role")).toBe("radiogroup");
+  });
+
+  it("should apply aria-label from label input", () => {
+    expect(groupElement.getAttribute("aria-label")).toBe("Status");
+  });
+
+  it("should share an auto-generated name across children", () => {
+    const names = inputs.map((i) => i.getAttribute("name"));
+    expect(names[0]).toBeTruthy();
+    expect(names[0]).toMatch(/^tedi-radio-group-\d+$/);
+    expect(new Set(names).size).toBe(1);
+  });
+
+  it("should reflect FormControl value into native checked state", () => {
+    fixture.componentInstance.control.setValue("active");
+    fixture.detectChanges();
+    expect(inputs[0].checked).toBe(false);
+    expect(inputs[1].checked).toBe(true);
+    expect(inputs[2].checked).toBe(false);
+  });
+
+  it("should update FormControl when a child is clicked", () => {
+    inputs[2].checked = true;
+    inputs[2].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.control.value).toBe("done");
+  });
+
+  it("should propagate disabled from FormControl to children", () => {
+    fixture.componentInstance.control.disable();
+    fixture.detectChanges();
+    expect(inputs.every((i) => i.disabled)).toBe(true);
+    expect(groupElement.getAttribute("aria-disabled")).toBe("true");
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [RadioGroupComponent, RadioComponent],
+  template: `
+    <tedi-radio-group [(value)]="selected">
+      <input tedi-radio type="radio" value="a" />
+      <input tedi-radio type="radio" value="b" />
+    </tedi-radio-group>
+  `,
+})
+class TwoWayHostComponent {
+  selected: string | null = "a";
+}
+
+describe("RadioGroupComponent — managed with [(value)]", () => {
+  let fixture: ComponentFixture<TwoWayHostComponent>;
+  let inputs: HTMLInputElement[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({ imports: [TwoWayHostComponent] });
+    fixture = TestBed.createComponent(TwoWayHostComponent);
+    fixture.detectChanges();
+    inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="radio"]'
+      )
+    ) as HTMLInputElement[];
+  });
+
+  it("should reflect initial value", () => {
+    expect(inputs[0].checked).toBe(true);
+    expect(inputs[1].checked).toBe(false);
+  });
+
+  it("should update bound value on click", () => {
+    inputs[1].checked = true;
+    inputs[1].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.selected).toBe("b");
+  });
+});
+
+@Component({
+  standalone: true,
+  imports: [
+    RadioGroupComponent,
+    RadioComponent,
+    RadioCardComponent,
+    RadioCardGroupComponent,
+    ReactiveFormsModule,
+  ],
+  template: `
+    <tedi-radio-group [formControl]="control">
+      <tedi-radio-card-group>
+        <label tedi-radio-card variant="primary">
+          <input tedi-radio type="radio" value="basic" />
+          Basic
+        </label>
+        <label tedi-radio-card variant="primary">
+          <input tedi-radio type="radio" value="pro" />
+          Pro
+        </label>
+      </tedi-radio-card-group>
+    </tedi-radio-group>
+  `,
+})
+class CardHostComponent {
+  control = new FormControl<string | null>(null);
+}
+
+describe("RadioGroupComponent — card children", () => {
+  it("should coordinate card-wrapped radios", () => {
+    TestBed.configureTestingModule({ imports: [CardHostComponent] });
+    const fixture = TestBed.createComponent(CardHostComponent);
+    fixture.detectChanges();
+    const inputs = Array.from(
+      (fixture.nativeElement as HTMLElement).querySelectorAll(
+        'input[type="radio"]'
+      )
+    ) as HTMLInputElement[];
+    fixture.componentInstance.control.setValue("pro");
+    fixture.detectChanges();
+    expect(inputs[0].checked).toBe(false);
+    expect(inputs[1].checked).toBe(true);
+
+    inputs[0].checked = true;
+    inputs[0].dispatchEvent(new Event("change", { bubbles: true }));
+    fixture.detectChanges();
+    expect(fixture.componentInstance.control.value).toBe("basic");
   });
 });

--- a/tedi/components/form/radio-group/radio-group.component.ts
+++ b/tedi/components/form/radio-group/radio-group.component.ts
@@ -38,7 +38,8 @@ let nextGroupId = 0;
   host: {
     class: "tedi-radio-group",
     "[attr.role]": "isManaged() ? 'radiogroup' : null",
-    "[attr.aria-labelledby]": "isManaged() && label() ? labelId : null",
+    "[attr.aria-labelledby]": "managedAriaLabelledby()",
+    "[attr.aria-label]": "managedAriaLabel()",
     "[attr.aria-disabled]": "isManaged() && isDisabled() ? 'true' : null",
   },
 })
@@ -60,8 +61,8 @@ export class RadioGroupComponent implements ControlValueAccessor {
    */
   readonly value = model<string | null>(null);
   /**
-   * Shared `name` attribute applied to every child radio. Auto-generated when
-   * omitted. Under SSR, pass an explicit `name` to avoid hydration mismatches.
+   * Shared `name` attribute applied to child radios. Auto-generated when
+   * omitted. Pass an explicit `name` to avoid SSR hydration mismatches.
    */
   readonly name = input<string>();
   /**
@@ -69,6 +70,16 @@ export class RadioGroupComponent implements ControlValueAccessor {
    * @default false
    */
   readonly disabled = input<boolean>(false);
+  /**
+   * Accessible name for the group. Use when no visible `label` is rendered.
+   * Ignored when `label` or `ariaLabelledby` is provided.
+   */
+  readonly ariaLabel = input<string>();
+  /**
+   * ID of an external element that labels the group. Ignored when `label` is
+   * provided.
+   */
+  readonly ariaLabelledby = input<string>();
 
   private readonly renderer = inject(Renderer2);
   private readonly autoName = `tedi-radio-group-${++nextGroupId}`;
@@ -82,6 +93,16 @@ export class RadioGroupComponent implements ControlValueAccessor {
 
   readonly isManaged = this.managed.asReadonly();
   readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
+  protected readonly managedAriaLabelledby = computed<string | null>(() => {
+    if (!this.isManaged()) return null;
+    if (this.label()) return this.labelId;
+    return this.ariaLabelledby() ?? null;
+  });
+  protected readonly managedAriaLabel = computed<string | null>(() => {
+    if (!this.isManaged()) return null;
+    if (this.label() || this.ariaLabelledby()) return null;
+    return this.ariaLabel() ?? null;
+  });
 
   constructor() {
     effect(() => {
@@ -93,6 +114,7 @@ export class RadioGroupComponent implements ControlValueAccessor {
     });
 
     effect(() => {
+      if (!this.isManaged()) return;
       const groupName = this.name() ?? this.autoName;
       for (const child of this.children()) {
         this.renderer.setAttribute(child.hostElement, "name", groupName);
@@ -121,14 +143,6 @@ export class RadioGroupComponent implements ControlValueAccessor {
 
   registerChild(child: RadioComponent): void {
     this.children.update((list) => [...list, child]);
-    this.renderer.setAttribute(
-      child.hostElement,
-      "name",
-      this.name() ?? this.autoName,
-    );
-    if (child.value() !== undefined) {
-      this.managed.set(true);
-    }
     this.applyCheckedTo(child);
   }
 

--- a/tedi/components/form/radio-group/radio-group.component.ts
+++ b/tedi/components/form/radio-group/radio-group.component.ts
@@ -116,6 +116,7 @@ export class RadioGroupComponent implements ControlValueAccessor {
 
   setDisabledState(isDisabled: boolean): void {
     this.cvaDisabled.set(isDisabled);
+    this.managed.set(true);
   }
 
   registerChild(child: RadioComponent): void {
@@ -125,6 +126,9 @@ export class RadioGroupComponent implements ControlValueAccessor {
       "name",
       this.name() ?? this.autoName,
     );
+    if (child.value() !== undefined) {
+      this.managed.set(true);
+    }
     this.applyCheckedTo(child);
   }
 

--- a/tedi/components/form/radio-group/radio-group.component.ts
+++ b/tedi/components/form/radio-group/radio-group.component.ts
@@ -88,8 +88,8 @@ export class RadioGroupComponent implements ControlValueAccessor {
   private readonly cvaDisabled = signal(false);
   private readonly managed = signal(false);
 
-  private onChange: (value: string | null) => void = () => {};
-  private onTouched: () => void = () => {};
+  private onChange: (value: string | null) => void = () => { };
+  private onTouched: () => void = () => { };
 
   readonly isManaged = this.managed.asReadonly();
   readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
@@ -106,8 +106,7 @@ export class RadioGroupComponent implements ControlValueAccessor {
 
   constructor() {
     effect(() => {
-      const v = this.value();
-      if (v !== null) {
+      if (this.value() !== null) {
         this.managed.set(true);
       }
       this.syncChildrenChecked();
@@ -171,9 +170,9 @@ export class RadioGroupComponent implements ControlValueAccessor {
 
   private applyCheckedTo(child: RadioComponent): void {
     if (!this.isManaged()) return;
-    const v = child.value();
-    if (v === undefined) return;
-    const desired = v === this.value();
+    const childVal = child.value();
+    if (childVal === undefined) return;
+    const desired = childVal === this.value();
     const el = child.hostElement;
     if (el.checked !== desired) {
       this.renderer.setProperty(el, "checked", desired);

--- a/tedi/components/form/radio-group/radio-group.component.ts
+++ b/tedi/components/form/radio-group/radio-group.component.ts
@@ -38,7 +38,7 @@ let nextGroupId = 0;
   host: {
     class: "tedi-radio-group",
     "[attr.role]": "isManaged() ? 'radiogroup' : null",
-    "[attr.aria-label]": "isManaged() ? (label() ?? null) : null",
+    "[attr.aria-labelledby]": "isManaged() && label() ? labelId : null",
     "[attr.aria-disabled]": "isManaged() && isDisabled() ? 'true' : null",
   },
 })
@@ -72,11 +72,10 @@ export class RadioGroupComponent implements ControlValueAccessor {
 
   private readonly renderer = inject(Renderer2);
   private readonly autoName = `tedi-radio-group-${++nextGroupId}`;
+  protected readonly labelId = `${this.autoName}-label`;
   private readonly children = signal<readonly RadioComponent[]>([]);
   private readonly cvaDisabled = signal(false);
   private readonly managed = signal(false);
-  private readonly intrinsicDisabled = new WeakMap<RadioComponent, boolean>();
-  private modelSeen = false;
 
   private onChange: (value: string | null) => void = () => {};
   private onTouched: () => void = () => {};
@@ -87,27 +86,10 @@ export class RadioGroupComponent implements ControlValueAccessor {
   constructor() {
     effect(() => {
       const v = this.value();
-      if (!this.modelSeen) {
-        this.modelSeen = true;
-        if (v !== null) {
-          this.managed.set(true);
-        }
-      } else {
+      if (v !== null) {
         this.managed.set(true);
       }
       this.syncChildrenChecked();
-    });
-
-    effect(() => {
-      const groupDisabled = this.isDisabled();
-      for (const child of this.children()) {
-        const intrinsic = this.intrinsicDisabled.get(child) ?? false;
-        this.renderer.setProperty(
-          child.hostElement,
-          "disabled",
-          groupDisabled || intrinsic,
-        );
-      }
     });
 
     effect(() => {
@@ -137,7 +119,6 @@ export class RadioGroupComponent implements ControlValueAccessor {
   }
 
   registerChild(child: RadioComponent): void {
-    this.intrinsicDisabled.set(child, child.hostElement.disabled);
     this.children.update((list) => [...list, child]);
     this.renderer.setAttribute(
       child.hostElement,
@@ -148,7 +129,6 @@ export class RadioGroupComponent implements ControlValueAccessor {
   }
 
   unregisterChild(child: RadioComponent): void {
-    this.intrinsicDisabled.delete(child);
     this.children.update((list) => list.filter((c) => c !== child));
   }
 

--- a/tedi/components/form/radio-group/radio-group.component.ts
+++ b/tedi/components/form/radio-group/radio-group.component.ts
@@ -1,12 +1,24 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  computed,
+  effect,
+  forwardRef,
+  inject,
   input,
+  isDevMode,
+  model,
+  Renderer2,
+  signal,
   ViewEncapsulation,
 } from "@angular/core";
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from "@angular/forms";
 import { TextComponent } from "../../base/text/text.component";
+import type { RadioComponent } from "../radio/radio.component";
 
 export type RadioGroupDirection = "horizontal" | "vertical";
+
+let nextGroupId = 0;
 
 @Component({
   standalone: true,
@@ -16,11 +28,21 @@ export type RadioGroupDirection = "horizontal" | "vertical";
   styleUrl: "./radio-group.component.scss",
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  providers: [
+    {
+      provide: NG_VALUE_ACCESSOR,
+      useExisting: forwardRef(() => RadioGroupComponent),
+      multi: true,
+    },
+  ],
   host: {
     class: "tedi-radio-group",
+    "[attr.role]": "isManaged() ? 'radiogroup' : null",
+    "[attr.aria-label]": "isManaged() ? (label() ?? null) : null",
+    "[attr.aria-disabled]": "isManaged() && isDisabled() ? 'true' : null",
   },
 })
-export class RadioGroupComponent {
+export class RadioGroupComponent implements ControlValueAccessor {
   /**
    * Label text displayed above the radio group.
    */
@@ -30,4 +52,142 @@ export class RadioGroupComponent {
    * @default horizontal
    */
   readonly direction = input<RadioGroupDirection>("horizontal");
+  /**
+   * Selected value. Bind with `[(value)]` or use a FormControl on the group.
+   * When set, the group enters managed mode and coordinates `checked` on every
+   * registered child.
+   * @default null
+   */
+  readonly value = model<string | null>(null);
+  /**
+   * Shared `name` attribute applied to every child radio. Auto-generated when
+   * omitted. Under SSR, pass an explicit `name` to avoid hydration mismatches.
+   */
+  readonly name = input<string>();
+  /**
+   * Disables the entire group. Propagates to all children.
+   * @default false
+   */
+  readonly disabled = input<boolean>(false);
+
+  private readonly renderer = inject(Renderer2);
+  private readonly autoName = `tedi-radio-group-${++nextGroupId}`;
+  private readonly children = signal<readonly RadioComponent[]>([]);
+  private readonly cvaDisabled = signal(false);
+  private readonly managed = signal(false);
+  private readonly intrinsicDisabled = new WeakMap<RadioComponent, boolean>();
+  private modelSeen = false;
+
+  private onChange: (value: string | null) => void = () => {};
+  private onTouched: () => void = () => {};
+
+  readonly isManaged = this.managed.asReadonly();
+  readonly isDisabled = computed(() => this.disabled() || this.cvaDisabled());
+
+  constructor() {
+    effect(() => {
+      const v = this.value();
+      if (!this.modelSeen) {
+        this.modelSeen = true;
+        if (v !== null) {
+          this.managed.set(true);
+        }
+      } else {
+        this.managed.set(true);
+      }
+      this.syncChildrenChecked();
+    });
+
+    effect(() => {
+      const groupDisabled = this.isDisabled();
+      for (const child of this.children()) {
+        const intrinsic = this.intrinsicDisabled.get(child) ?? false;
+        this.renderer.setProperty(
+          child.hostElement,
+          "disabled",
+          groupDisabled || intrinsic,
+        );
+      }
+    });
+
+    effect(() => {
+      const groupName = this.name() ?? this.autoName;
+      for (const child of this.children()) {
+        this.renderer.setAttribute(child.hostElement, "name", groupName);
+      }
+    });
+  }
+
+  writeValue(value: string | null): void {
+    this.value.set(value);
+    this.managed.set(true);
+  }
+
+  registerOnChange(fn: (value: string | null) => void): void {
+    this.onChange = fn;
+    this.managed.set(true);
+  }
+
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.cvaDisabled.set(isDisabled);
+  }
+
+  registerChild(child: RadioComponent): void {
+    this.intrinsicDisabled.set(child, child.hostElement.disabled);
+    this.children.update((list) => [...list, child]);
+    this.renderer.setAttribute(
+      child.hostElement,
+      "name",
+      this.name() ?? this.autoName,
+    );
+    this.applyCheckedTo(child);
+  }
+
+  unregisterChild(child: RadioComponent): void {
+    this.intrinsicDisabled.delete(child);
+    this.children.update((list) => list.filter((c) => c !== child));
+  }
+
+  onChildChange(value: string): void {
+    if (!this.isManaged()) return;
+    if (this.value() === value) return;
+    this.value.set(value);
+    this.onChange(value);
+    this.onTouched();
+  }
+
+  isSelected(value: string | undefined): boolean {
+    return value !== undefined && this.value() === value;
+  }
+
+  private syncChildrenChecked(): void {
+    if (!this.isManaged()) return;
+    for (const child of this.children()) {
+      this.applyCheckedTo(child);
+    }
+  }
+
+  private applyCheckedTo(child: RadioComponent): void {
+    if (!this.isManaged()) return;
+    const v = child.value();
+    if (v === undefined) return;
+    const desired = v === this.value();
+    const el = child.hostElement;
+    if (el.checked !== desired) {
+      this.renderer.setProperty(el, "checked", desired);
+    }
+  }
+
+  /** @internal */
+  warnMissingValue(): void {
+    if (isDevMode()) {
+      console.warn(
+        "[tedi-radio-group] A radio inside a managed group is missing a [value] input and will be ignored.",
+      );
+    }
+  }
 }

--- a/tedi/components/form/radio/radio.component.scss
+++ b/tedi/components/form/radio/radio.component.scss
@@ -71,12 +71,14 @@ input[tedi-radio][type="radio"] {
   }
 
   &:not(:checked, :disabled).tedi-radio--invalid,
-  &:user-invalid,
-  &.ng-invalid.ng-touched {
+  &:not(:checked, :disabled):user-invalid,
+  &:not(:checked, :disabled).ng-invalid.ng-touched {
+    background-color: var(--form-checkbox-radio-default-background-error);
     border-color: var(--form-general-feedback-error-border);
 
     &:hover {
-      border-color: var(--form-checkbox-radio-default-border-hover);
+      border-color: var(--form-general-feedback-error-border);
+      box-shadow: 0 0 0 1px var(--form-general-feedback-error-border);
     }
   }
 
@@ -86,6 +88,14 @@ input[tedi-radio][type="radio"] {
     width: var(--form-checkbox-radio-size-large);
     height: var(--form-checkbox-radio-size-large);
   }
+}
+
+label:has(input[tedi-radio]:not(:disabled)) {
+  cursor: pointer;
+}
+
+label:has(input[tedi-radio]:disabled) {
+  cursor: not-allowed;
 }
 
 label:has(input[tedi-radio]) + tedi-feedback-text {

--- a/tedi/components/form/radio/radio.component.scss
+++ b/tedi/components/form/radio/radio.component.scss
@@ -5,6 +5,7 @@ input[tedi-radio][type="radio"] {
 
   position: relative;
   width: var(--form-checkbox-radio-size-responsive);
+  min-width: var(--form-checkbox-radio-size-responsive);
   height: var(--form-checkbox-radio-size-responsive);
   padding: 0;
   margin: 0;
@@ -98,7 +99,7 @@ label:has(input[tedi-radio]:disabled) {
   cursor: not-allowed;
 }
 
-label:has(input[tedi-radio]) + tedi-feedback-text {
+label:has(input[tedi-radio])+tedi-feedback-text {
   padding-left: var(--form-checkbox-radio-size-responsive);
   margin-left: var(--form-checkbox-radio-inner-spacing);
 }

--- a/tedi/components/form/radio/radio.component.scss
+++ b/tedi/components/form/radio/radio.component.scss
@@ -66,9 +66,8 @@ input[tedi-radio][type="radio"] {
   }
 
   &:focus-visible {
-    outline-width: 2px;
-    outline-style: solid;
-    outline-offset: 2px;
+    outline: var(--tedi-borders-02) solid var(--tedi-primary-500);
+    outline-offset: var(--tedi-borders-01);
   }
 
   &:not(:checked, :disabled).tedi-radio--invalid,

--- a/tedi/components/form/radio/radio.component.ts
+++ b/tedi/components/form/radio/radio.component.ts
@@ -1,6 +1,8 @@
 import {
+  booleanAttribute,
   ChangeDetectionStrategy,
   Component,
+  computed,
   ElementRef,
   inject,
   input,
@@ -22,6 +24,7 @@ export type RadioSize = "default" | "large";
   host: {
     "[class.tedi-radio--large]": "size() === 'large'",
     "[class.tedi-radio--invalid]": "invalid()",
+    "[disabled]": "effectiveDisabled()",
     "(change)": "handleChange()",
   },
 })
@@ -42,11 +45,21 @@ export class RadioComponent implements OnInit, OnDestroy {
    * binding). Ignored otherwise.
    */
   readonly value = input<string>();
+  /**
+   * Disables this radio. An enclosing disabled `<tedi-radio-group>` forces
+   * disabled regardless of this input.
+   * @default false
+   */
+  readonly disabled = input(false, { transform: booleanAttribute });
 
   private readonly elementRef =
     inject<ElementRef<HTMLInputElement>>(ElementRef);
   private readonly group = inject(RadioGroupComponent, { optional: true });
   private warned = false;
+
+  readonly effectiveDisabled = computed(
+    () => this.disabled() || (this.group?.isDisabled() ?? false),
+  );
 
   get hostElement(): HTMLInputElement {
     return this.elementRef.nativeElement;
@@ -62,7 +75,7 @@ export class RadioComponent implements OnInit, OnDestroy {
 
   handleChange(): void {
     if (!this.group || !this.group.isManaged()) return;
-    if (this.hostElement.disabled) return;
+    if (this.effectiveDisabled()) return;
     const v = this.value();
     if (v === undefined) {
       if (!this.warned) {

--- a/tedi/components/form/radio/radio.component.ts
+++ b/tedi/components/form/radio/radio.component.ts
@@ -1,9 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  ElementRef,
+  inject,
   input,
+  OnDestroy,
+  OnInit,
   ViewEncapsulation,
 } from "@angular/core";
+import { RadioGroupComponent } from "../radio-group/radio-group.component";
 
 export type RadioSize = "default" | "large";
 
@@ -17,9 +22,10 @@ export type RadioSize = "default" | "large";
   host: {
     "[class.tedi-radio--large]": "size() === 'large'",
     "[class.tedi-radio--invalid]": "invalid()",
+    "(change)": "handleChange()",
   },
 })
-export class RadioComponent {
+export class RadioComponent implements OnInit, OnDestroy {
   /**
    * Size of the radio.
    * @default default
@@ -30,4 +36,43 @@ export class RadioComponent {
    * @default false
    */
   readonly invalid = input(false);
+  /**
+   * Identity of this radio inside a managed `<tedi-radio-group>`. Required
+   * when the parent group is managed (has a FormControl or `[(value)]`
+   * binding). Ignored otherwise.
+   */
+  readonly value = input<string>();
+
+  private readonly elementRef =
+    inject<ElementRef<HTMLInputElement>>(ElementRef);
+  private readonly group = inject(RadioGroupComponent, { optional: true });
+  private warned = false;
+
+  get hostElement(): HTMLInputElement {
+    return this.elementRef.nativeElement;
+  }
+
+  ngOnInit(): void {
+    this.group?.registerChild(this);
+  }
+
+  ngOnDestroy(): void {
+    this.group?.unregisterChild(this);
+  }
+
+  handleChange(): void {
+    if (!this.group || !this.group.isManaged()) return;
+    if (this.hostElement.disabled) return;
+    const v = this.value();
+    if (v === undefined) {
+      if (!this.warned) {
+        this.warned = true;
+        this.group.warnMissingValue();
+      }
+      return;
+    }
+    if (this.hostElement.checked) {
+      this.group.onChildChange(v);
+    }
+  }
 }

--- a/tedi/components/form/radio/radio.stories.ts
+++ b/tedi/components/form/radio/radio.stories.ts
@@ -4,6 +4,7 @@ import {
   moduleMetadata,
   StoryObj,
 } from "@storybook/angular";
+import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { RadioComponent } from "./radio.component";
 import { RadioCardComponent } from "../radio-card/radio-card.component";
 import { RadioGroupComponent } from "../radio-group/radio-group.component";
@@ -18,6 +19,7 @@ import { TooltipTriggerComponent } from "../../overlay/tooltip/tooltip-trigger/t
 import { TooltipContentComponent } from "../../overlay/tooltip/tooltip-content/tooltip-content.component";
 import { InfoButtonComponent } from "../../buttons/info-button/info-button.component";
 import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
+import { AlertComponent } from "../../notifications/alert/alert.component";
 
 /**
  * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.41.64?node-id=6149-138013&m=dev" target="_blank">Figma ↗</a><br />
@@ -43,6 +45,8 @@ export default {
         TooltipContentComponent,
         InfoButtonComponent,
         FeedbackTextComponent,
+        AlertComponent,
+        ReactiveFormsModule,
       ],
     }),
   ],
@@ -474,45 +478,45 @@ export const RadioCardsGrouped: StoryObj<RadioComponent> = {
       <tedi-row [gapY]="3" [xs]="{cols: 1}" [md]="{cols: 2}">
         <tedi-col class="flex flex-column gap-2">
           <p tedi-text>Primary</p>
-          <div style="display: inline-flex;">
-            <label tedi-radio-card variant="primary" [grouped]="true">
+          <tedi-radio-card-group [grouped]="true">
+            <label tedi-radio-card variant="primary">
               <input tedi-radio type="radio" name="card-group-primary" />
               Text
             </label>
-            <label tedi-radio-card variant="primary" [grouped]="true">
+            <label tedi-radio-card variant="primary">
               <input tedi-radio type="radio" name="card-group-primary" />
               Text
             </label>
-            <label tedi-radio-card variant="primary" [grouped]="true">
+            <label tedi-radio-card variant="primary">
               <input tedi-radio type="radio" name="card-group-primary" checked />
               Text
             </label>
-            <label tedi-radio-card variant="primary" [grouped]="true">
+            <label tedi-radio-card variant="primary">
               <input tedi-radio type="radio" name="card-group-primary" />
               Text
             </label>
-          </div>
+          </tedi-radio-card-group>
         </tedi-col>
         <tedi-col class="flex flex-column gap-2">
           <p tedi-text>Secondary</p>
-          <div style="display: inline-flex;">
-            <label tedi-radio-card variant="secondary" [grouped]="true">
+          <tedi-radio-card-group [grouped]="true">
+            <label tedi-radio-card variant="secondary">
               <input tedi-radio type="radio" name="card-group-secondary" />
               Text
             </label>
-            <label tedi-radio-card variant="secondary" [grouped]="true">
+            <label tedi-radio-card variant="secondary">
               <input tedi-radio type="radio" name="card-group-secondary" checked />
               Text
             </label>
-            <label tedi-radio-card variant="secondary" [grouped]="true">
+            <label tedi-radio-card variant="secondary">
               <input tedi-radio type="radio" name="card-group-secondary" />
               Text
             </label>
-            <label tedi-radio-card variant="secondary" [grouped]="true">
+            <label tedi-radio-card variant="secondary">
               <input tedi-radio type="radio" name="card-group-secondary" />
               Text
             </label>
-          </div>
+          </tedi-radio-card-group>
         </tedi-col>
       </tedi-row>
     `,
@@ -582,43 +586,43 @@ export const RadioCardsGroupedWithDescription: StoryObj<RadioComponent> = {
       <tedi-row [gapY]="3" [xs]="{cols: 1}" [md]="{cols: 2}">
         <tedi-col class="flex flex-column gap-2">
           <p tedi-text>Primary</p>
-          <div style="display: inline-flex;">
-            <label tedi-radio-card variant="primary" [grouped]="true">
+          <tedi-radio-card-group [grouped]="true">
+            <label tedi-radio-card variant="primary">
               <input tedi-radio type="radio" name="card-group-desc-primary" />
               Text
               <tedi-feedback-text text="Description" />
             </label>
-            <label tedi-radio-card variant="primary" [grouped]="true">
+            <label tedi-radio-card variant="primary">
               <input tedi-radio type="radio" name="card-group-desc-primary" />
               Text
               <tedi-feedback-text text="Description" />
             </label>
-            <label tedi-radio-card variant="primary" [grouped]="true">
+            <label tedi-radio-card variant="primary">
               <input tedi-radio type="radio" name="card-group-desc-primary" checked />
               Text
               <tedi-feedback-text text="Description" />
             </label>
-          </div>
+          </tedi-radio-card-group>
         </tedi-col>
         <tedi-col class="flex flex-column gap-2">
           <p tedi-text>Secondary</p>
-          <div style="display: inline-flex;">
-            <label tedi-radio-card variant="secondary" [grouped]="true">
+          <tedi-radio-card-group [grouped]="true">
+            <label tedi-radio-card variant="secondary">
               <input tedi-radio type="radio" name="card-group-desc-secondary" />
               Text
               <tedi-feedback-text text="Description" />
             </label>
-            <label tedi-radio-card variant="secondary" [grouped]="true">
+            <label tedi-radio-card variant="secondary">
               <input tedi-radio type="radio" name="card-group-desc-secondary" checked />
               Text
               <tedi-feedback-text text="Description" />
             </label>
-            <label tedi-radio-card variant="secondary" [grouped]="true">
+            <label tedi-radio-card variant="secondary">
               <input tedi-radio type="radio" name="card-group-desc-secondary" />
               Text
               <tedi-feedback-text text="Description" />
             </label>
-          </div>
+          </tedi-radio-card-group>
         </tedi-col>
       </tedi-row>
     `,
@@ -843,4 +847,104 @@ export const RadioCardStates: StoryObj<RadioComponent> = {
       </tedi-row>
     `,
   }),
+};
+
+/**
+ * The group supports two form-binding modes:
+ *
+ * - **Group-level**: bind `[formControl]` to `<tedi-radio-group>`. The group
+ *   coordinates `name`, `checked`, and `disabled` across children. Emits the
+ *   selected `value` (string) as a single control.
+ * - **Individual-level (Angular native)**: bind `[formControl]` to each
+ *   `<input type="radio">` using Angular's built-in `RadioControlValueAccessor`.
+ *   All radios sharing the same control coordinate via their `name` attribute.
+ */
+export const WithReactiveForms: StoryObj<RadioComponent> = {
+  render: () => {
+    const statusControl = new FormControl<string | null>("active");
+    const planControl = new FormControl<string | null>("pro");
+    const priorityControl = new FormControl<string | null>("medium");
+
+    return {
+      props: { statusControl, planControl, priorityControl },
+      template: `
+        <tedi-row cols="1" [gapY]="3">
+          <tedi-col>
+            <tedi-radio-group label="Status" name="status" [formControl]="statusControl">
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-radio type="radio" value="all" />
+                All
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-radio type="radio" value="active" />
+                Active
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-radio type="radio" value="done" />
+                Done
+              </label>
+            </tedi-radio-group>
+          </tedi-col>
+
+          <tedi-col>
+            <tedi-radio-group label="Plan" name="plan" [formControl]="planControl">
+              <tedi-radio-card-group [grouped]="true">
+                <label tedi-radio-card variant="primary">
+                  <input tedi-radio type="radio" value="basic" />
+                  Basic
+                </label>
+                <label tedi-radio-card variant="primary">
+                  <input tedi-radio type="radio" value="pro" />
+                  Pro
+                </label>
+                <label tedi-radio-card variant="primary">
+                  <input tedi-radio type="radio" value="enterprise" />
+                  Enterprise
+                </label>
+              </tedi-radio-card-group>
+            </tedi-radio-group>
+          </tedi-col>
+
+          <tedi-col>
+            <tedi-radio-group label="Priority">
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-radio type="radio" [formControl]="priorityControl" name="priority" value="low" />
+                Low
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-radio type="radio" [formControl]="priorityControl" name="priority" value="medium" />
+                Medium
+              </label>
+              <label tedi-label color="primary" class="flex align-items-center gap-2">
+                <input tedi-radio type="radio" [formControl]="priorityControl" name="priority" value="high" />
+                High
+              </label>
+            </tedi-radio-group>
+          </tedi-col>
+
+          <tedi-col>
+            <tedi-alert type="info" [showClose]="false">
+              <pre tedi-text modifiers="small">{{ {
+  status: {
+    value: statusControl.value,
+    touched: statusControl.touched,
+    dirty: statusControl.dirty
+  },
+  plan: {
+    value: planControl.value,
+    touched: planControl.touched,
+    dirty: planControl.dirty
+  },
+  priority: {
+    value: priorityControl.value,
+    touched: priorityControl.touched,
+    dirty: priorityControl.dirty
+  }
+} | json }}</pre>
+            </tedi-alert>
+          </tedi-col>
+        </tedi-row>
+      `,
+    };
+  },
 };

--- a/tedi/components/form/radio/radio.stories.ts
+++ b/tedi/components/form/radio/radio.stories.ts
@@ -366,6 +366,7 @@ export const States: StoryObj<RadioComponent> = {
     pseudo: {
       hover: "#Hover",
       active: "#Active",
+      focusVisible: "#Focus",
     },
   },
   render: (args) => ({
@@ -393,6 +394,12 @@ export const States: StoryObj<RadioComponent> = {
         <strong>Active</strong>
         <label tedi-label color="primary" class="flex align-items-center gap-2">
           <input tedi-radio type="radio" name="state-active" id="Active" />
+          Text
+        </label>
+
+        <strong>Focus</strong>
+        <label tedi-label color="primary" class="flex align-items-center gap-2">
+          <input tedi-radio type="radio" name="state-focus" id="Focus" />
           Text
         </label>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Checkbox and radio groups implement form binding (ControlValueAccessor) with two-way sync, disabled propagation, accessible naming, and per-option `value`/`disabled` inputs.
  - Radio card group and radio cards inherit/propagate a grouped layout option.
  - Storybook: new Reactive Forms stories and a Focus visual state.

- **Style**
  - Unified focus-visible outlines and selected-card visuals using design tokens; improved invalid/disabled cursor rules.

- **Tests**
  - Expanded coverage for managed/unmanaged groups, disabled behavior, inheritance, card-wrapped controls, and value synchronization.

- **Documentation**
  - Updated API and form usage docs for checkbox/radio groups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->