### PR TITLE
chore: enabled chromatic TurboSnap #414

### DIFF
--- a/.github/workflows/angular-release.yml
+++ b/.github/workflows/angular-release.yml
@@ -53,9 +53,6 @@ jobs:
       - name: Install dependencies
         run: |
           npm ci --cache .npm --prefer-offline
-      - name: Build Storybook
-        run: |
-          npm run build:sb
       - name: Publish to Chromatic
         run: |
           CHROMATIC_PROJECT_TOKEN=${{ secrets.CHROMATIC_TOKEN }} npm run chromatic

--- a/.github/workflows/angular-test-and-lint.yml
+++ b/.github/workflows/angular-test-and-lint.yml
@@ -133,10 +133,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
-
-      - name: Fetch baseline branch (rc)
-        run: git fetch origin rc
+          ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Node
         uses: actions/setup-node@v4
@@ -147,11 +144,6 @@ jobs:
         run: |
           npm ci --cache .npm --prefer-offline
 
-      - name: Build Storybook
-        run: |
-          npm run build:sb
-
       - name: Publish to Chromatic
         run: |
-          echo "CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_TOKEN }}"
           CHROMATIC_PROJECT_TOKEN=${{ secrets.CHROMATIC_TOKEN }} npm run chromatic

--- a/angular.json
+++ b/angular.json
@@ -51,7 +51,8 @@
               "./node_modules/@tedi-design-system/core/index.scss",
               "./node_modules/@tedi-design-system/core/tedi-storybook-styles.scss"
             ],
-            "experimentalZoneless": true
+            "experimentalZoneless": true,
+            "statsJson": true
           }
         },
         "lint": {

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://www.chromatic.com/config-file.schema.json",
   "buildScriptName": "build:sb",
-  "onlyStoryFiles": ["tedi/**/*.stories.*"],
   "autoAcceptChanges": "main",
   "exitOnceUploaded": true,
   "skip": "dependabot/**",

--- a/chromatic.config.json
+++ b/chromatic.config.json
@@ -1,7 +1,9 @@
 {
   "$schema": "https://www.chromatic.com/config-file.schema.json",
   "buildScriptName": "build:sb",
+  "onlyStoryFiles": ["tedi/**/*.stories.*"],
   "autoAcceptChanges": "main",
   "exitOnceUploaded": true,
-  "skip": "dependabot/**"
+  "skip": "dependabot/**",
+  "onlyChanged": true
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:coverage": "jest --config ./jest.config.ts --coverage",
     "install:clean": "rm -rf node_modules && npm install",
     "release": "npx semantic-release",
-    "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN --build-script-name=build:sb --baseline-branch=rc --include=\"tedi/**/*.stories.*\""
+    "chromatic": "npx chromatic --project-token=$CHROMATIC_PROJECT_TOKEN"
   },
   "peerDependencies": {
     "@angular/animations": "^19.0.0 || ^20.0.0 || ^21.0.0",

--- a/tedi/components/buttons/closing-button/closing-button.stories.ts
+++ b/tedi/components/buttons/closing-button/closing-button.stories.ts
@@ -6,12 +6,10 @@ import {
 } from "@storybook/angular";
 
 import { ClosingButtonComponent } from "./closing-button.component";
-import {
-  ColComponent,
-  IconComponent,
-  RowComponent,
-  VerticalSpacingDirective,
-} from "@tedi-design-system/angular/tedi";
+import { ColComponent } from "../../helpers/grid/col/col.component";
+import { IconComponent } from "../../base/icon/icon.component";
+import { RowComponent } from "../../helpers/grid/row/row.component";
+import { VerticalSpacingDirective } from "../../../directives/vertical-spacing/vertical-spacing.directive";
 
 const PSEUDO_STATE = ["Default", "Hover", "Active", "Focus"];
 

--- a/tedi/components/cards/accordion/accordion.stories.ts
+++ b/tedi/components/cards/accordion/accordion.stories.ts
@@ -1,13 +1,11 @@
 import { Meta, StoryObj, moduleMetadata } from "@storybook/angular";
-import {
-  AccordionComponent,
-  AccordionItemComponent,
-  IconComponent,
-  TextComponent,
-  ButtonComponent,
-  StatusBadgeComponent,
-  CheckboxComponent,
-} from "@tedi-design-system/angular/tedi";
+import { AccordionComponent } from "./accordion/accordion.component";
+import { AccordionItemComponent } from "./accordion-item/accordion-item.component";
+import { IconComponent } from "../../base/icon/icon.component";
+import { TextComponent } from "../../base/text/text.component";
+import { ButtonComponent } from "../../buttons/button/button.component";
+import { StatusBadgeComponent } from "../../tags/status-badge/status-badge.component";
+import { CheckboxComponent } from "../../form/checkbox/checkbox.component";
 import { TEDI_TRANSLATION_DEFAULT_TOKEN } from "../../../tokens/translation.token";
 
 document.cookie = "tedi-lang=en; path=/;";

--- a/tedi/components/cards/accordion/accordion.stories.ts
+++ b/tedi/components/cards/accordion/accordion.stories.ts
@@ -6,6 +6,7 @@ import { TextComponent } from "../../base/text/text.component";
 import { ButtonComponent } from "../../buttons/button/button.component";
 import { StatusBadgeComponent } from "../../tags/status-badge/status-badge.component";
 import { CheckboxComponent } from "../../form/checkbox/checkbox.component";
+import { LabelComponent } from "../../form/label/label.component";
 import { TEDI_TRANSLATION_DEFAULT_TOKEN } from "../../../tokens/translation.token";
 
 document.cookie = "tedi-lang=en; path=/;";
@@ -27,6 +28,7 @@ export default {
         ButtonComponent,
         StatusBadgeComponent,
         CheckboxComponent,
+        LabelComponent,
       ],
       providers: [{ provide: TEDI_TRANSLATION_DEFAULT_TOKEN, useValue: "en" }],
     }),

--- a/tedi/components/content/text-group/text-group.stories.ts
+++ b/tedi/components/content/text-group/text-group.stories.ts
@@ -8,11 +8,9 @@ import {
 } from "@storybook/angular";
 
 import { TextGroupComponent } from "./text-group.component";
-import {
-  IconComponent,
-  RowComponent,
-  VerticalSpacingDirective,
-} from "@tedi-design-system/angular/tedi";
+import { IconComponent } from "../../base/icon/icon.component";
+import { RowComponent } from "../../helpers/grid/row/row.component";
+import { VerticalSpacingDirective } from "../../../directives/vertical-spacing/vertical-spacing.directive";
 import { createBreakpointArgTypes } from "../../../../src/dev-tools/createBreakpointArgTypes";
 import { StatusBadgeComponent } from "@tedi-design-system/angular/community";
 

--- a/tedi/components/form/text-field/text-field.stories.ts
+++ b/tedi/components/form/text-field/text-field.stories.ts
@@ -10,15 +10,13 @@ import {
   moduleMetadata,
   StoryObj,
 } from "@storybook/angular";
-import {
-  TextFieldComponent,
-  FormFieldComponent,
-  ColComponent,
-  RowComponent,
-  FeedbackTextComponent,
-  TextComponent,
-  LabelComponent,
-} from "@tedi-design-system/angular/tedi";
+import { TextFieldComponent } from "./text-field.component";
+import { FormFieldComponent } from "../form-field/form-field.component";
+import { ColComponent } from "../../helpers/grid/col/col.component";
+import { RowComponent } from "../../helpers/grid/row/row.component";
+import { FeedbackTextComponent } from "../feedback-text/feedback-text.component";
+import { TextComponent } from "../../base/text/text.component";
+import { LabelComponent } from "../label/label.component";
 
 const PSEUDO_STATE = ["Default", "Hover", "Active", "Disabled", "Focus"];
 

--- a/tedi/components/layout/footer/footer.stories.ts
+++ b/tedi/components/layout/footer/footer.stories.ts
@@ -10,8 +10,8 @@ import { FooterBodyComponent } from "./footer-body/footer-body.component";
 import { FooterSectionComponent } from "./footer-section/footer-section.component";
 import { FooterSideComponent } from "./footer-side/footer-side.component";
 import { FooterBottomComponent } from "./footer-bottom/footer-bottom.component";
-import { TextComponent } from "@tedi-design-system/angular/tedi";
-import { LinkComponent } from "@tedi-design-system/angular/tedi";
+import { TextComponent } from "../../base/text/text.component";
+import { LinkComponent } from "../../navigation/link/link.component";
 
 /**
  * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.12.16--work-in-progress-?node-id=6459-181755&m=dev" target="_BLANK">Figma ↗</a><br/>

--- a/tedi/components/tags/status-badge/status-badge.stories.ts
+++ b/tedi/components/tags/status-badge/status-badge.stories.ts
@@ -4,21 +4,21 @@ import {
   moduleMetadata,
   argsToTemplate,
 } from "@storybook/angular";
+import { IconComponent } from "../../base/icon/icon.component";
+import { TextComponent } from "../../base/text/text.component";
+import { ButtonComponent } from "../../buttons/button/button.component";
 import {
-  IconComponent,
-  TextComponent,
-  ButtonComponent,
   StatusBadgeComponent,
-  ColComponent,
-  RowComponent,
-  TooltipComponent,
-  TooltipContentComponent,
-  TooltipTriggerComponent,
   StatusBadgeColor,
   StatusBadgeSize,
   StatusBadgeStatus,
   StatusBadgeVariant,
-} from "@tedi-design-system/angular/tedi";
+} from "./status-badge.component";
+import { ColComponent } from "../../helpers/grid/col/col.component";
+import { RowComponent } from "../../helpers/grid/row/row.component";
+import { TooltipComponent } from "../../overlay/tooltip/tooltip.component";
+import { TooltipContentComponent } from "../../overlay/tooltip/tooltip-content/tooltip-content.component";
+import { TooltipTriggerComponent } from "../../overlay/tooltip/tooltip-trigger/tooltip-trigger.component";
 
 const colors: StatusBadgeColor[] = [
   "neutral",


### PR DESCRIPTION
* Removed the hardcoded "rc" base branch, chromatic should detect it automatically. "rc" doesn't work anyway with hotfixes

* Why imports from tedi main file were removed - as every component is exported from there, Chromatic detects all of them as changed dependency and analyses everything, effectively bypassing TurboSnap

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline by removing unnecessary Storybook build steps before publishing.
  * Enhanced Chromatic configuration to process only changed story files, reducing build time.
  * Refactored component imports in story files to use direct relative imports instead of barrel imports, improving build efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->