### PR TITLE
fix(select): clear placeholder on value select #432

### DIFF
--- a/tedi/components/form/select/select.component.html
+++ b/tedi/components/form/select/select.component.html
@@ -61,7 +61,7 @@
           type="text"
           class="tedi-select__search-input"
           [class.tedi-select__search-input--hidden]="showSingleSelectedValue()"
-          [placeholder]="placeholder()"
+          [placeholder]="showSingleSelectedValue() ? '' : placeholder()"
           [value]="searchTerm()"
           [disabled]="disabled()"
           (input)="onSearchInput($event)"

--- a/tedi/components/form/select/select.component.spec.ts
+++ b/tedi/components/form/select/select.component.spec.ts
@@ -548,6 +548,20 @@ describe("SelectComponent", () => {
       expect(select.searchTerm()).toBe("");
     }));
 
+    it("should not show placeholder on search input after a value is selected", fakeAsync(() => {
+      getTrigger().click();
+      fixture.detectChanges();
+      tick();
+
+      const options = getOptions();
+      options[0].click();
+      fixture.detectChanges();
+      tick();
+
+      const input = getSearchInput();
+      expect(input.getAttribute("placeholder")).toBe("");
+    }));
+
     it("should open dropdown when typing", fakeAsync(() => {
       const input = getSearchInput();
       input.value = "O";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved searchable select components by hiding the input placeholder text when an option is selected, then restoring it when searching for a different item. This provides clearer visual feedback during selection workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->