### PR TITLE
feat(dropdown): Added support for wrapped buttons #468

### DIFF
--- a/skills/tedi-angular/references/components.md
+++ b/skills/tedi-angular/references/components.md
@@ -1342,6 +1342,7 @@ The `[(open)]` binding approach is deprecated. Use `ModalService.open()` for new
 - `position: DropdownPosition = "bottom-start"`
 - `preventOverflow: boolean = true`
 - `appendTo: string`
+- `hideOnScroll: boolean = false` — close the dropdown when the page scrolls
 
 ```html
 <tedi-dropdown [(value)]="selected">

--- a/tedi/components/overlay/dropdown/dropdown-item/dropdown-item.component.ts
+++ b/tedi/components/overlay/dropdown/dropdown-item/dropdown-item.component.ts
@@ -121,6 +121,11 @@ export class DropdownItemComponent {
         this.dropdown.hideDropdown();
         this.dropdown.dropdownTrigger()?.focus();
         break;
+
+      case "Tab":
+        event.preventDefault();
+        this.dropdown.tabOutOfDropdown(event.shiftKey);
+        break;
     }
   }
 

--- a/tedi/components/overlay/dropdown/dropdown-item/dropdown-item.component.ts
+++ b/tedi/components/overlay/dropdown/dropdown-item/dropdown-item.component.ts
@@ -119,7 +119,7 @@ export class DropdownItemComponent {
       case "Escape":
         event.preventDefault();
         this.dropdown.hideDropdown();
-        this.dropdown.dropdownTrigger()?.host.nativeElement.focus();
+        this.dropdown.dropdownTrigger()?.focus();
         break;
     }
   }
@@ -134,6 +134,6 @@ export class DropdownItemComponent {
     if (!this.closeOnSelect()) return;
 
     this.dropdown.hideDropdown();
-    this.dropdown.dropdownTrigger()?.host.nativeElement.focus();
+    this.dropdown.dropdownTrigger()?.focus();
   }
 }

--- a/tedi/components/overlay/dropdown/dropdown-trigger/dropdown-trigger.directive.ts
+++ b/tedi/components/overlay/dropdown/dropdown-trigger/dropdown-trigger.directive.ts
@@ -69,6 +69,12 @@ export class DropdownTriggerDirective implements AfterViewInit {
     this.triggerElement()?.focus();
   }
 
+  /** The element that is actually in the tab order — the resolved interactive
+   * element, which may be a button nested inside a wrapping component. */
+  get focusableElement(): HTMLElement {
+    return this.triggerElement() ?? this.host.nativeElement;
+  }
+
   @HostListener("click")
   onClick() {
     this.dropdown.toggleDropdown();

--- a/tedi/components/overlay/dropdown/dropdown-trigger/dropdown-trigger.directive.ts
+++ b/tedi/components/overlay/dropdown/dropdown-trigger/dropdown-trigger.directive.ts
@@ -1,35 +1,72 @@
 import {
+  AfterViewInit,
   Directive,
   ElementRef,
   HostListener,
+  Renderer2,
+  effect,
   inject,
   input,
+  signal,
 } from "@angular/core";
 import { DropdownComponent } from "../dropdown.component";
 
 export type DropdownTriggerAriaHasPopup = "menu" | "listbox" | "dialog" | "true";
 
+const FOCUSABLE_SELECTOR = "button, a[href], [tabindex]";
+
 @Directive({
   standalone: true,
   selector: "[tedi-dropdown-trigger]",
-  host: {
-    "[attr.id]": "dropdown.containerId() + '_trigger'",
-    "[attr.aria-controls]": "dropdown.containerId()",
-    "[attr.aria-expanded]": "dropdown.floatUiComponent().state",
-    "[attr.aria-haspopup]": "ariaHaspopup()",
-    "[attr.role]": "isButton ? null : 'button'",
-    "[attr.tabindex]": "isButton ? null : '0'",
-  },
 })
-export class DropdownTriggerDirective {
+export class DropdownTriggerDirective implements AfterViewInit {
   /** Defines the aria-haspopup attribute for the trigger, informing assistive technologies whether it opens a menu or listbox. Improves accessibility by describing the type of popup. */
   readonly ariaHaspopup = input<DropdownTriggerAriaHasPopup>("menu");
 
   readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
   readonly dropdown = inject(DropdownComponent);
+  private readonly renderer = inject(Renderer2);
 
-  get isButton(): boolean {
-    return this.host.nativeElement.tagName === "BUTTON";
+  /**
+   * The element that actually receives focus and ARIA semantics. When the directive
+   * sits on a native `<button>`/`<a href>` that element is used directly. When it wraps
+   * a button component (e.g. `<app-button>` that renders its own native button), the
+   * inner focusable element is used instead — otherwise the wrapper and the inner button
+   * would both be tab stops, and the ARIA state would land on the wrong element.
+   */
+  private readonly triggerElement = signal<HTMLElement | null>(null);
+
+  constructor() {
+    effect(() => {
+      const el = this.triggerElement();
+      if (!el) return;
+
+      this.renderer.setAttribute(
+        el,
+        "id",
+        `${this.dropdown.containerId()}_trigger`,
+      );
+      this.renderer.setAttribute(el, "aria-controls", this.dropdown.containerId());
+      this.renderer.setAttribute(el, "aria-haspopup", this.ariaHaspopup());
+      this.renderer.setAttribute(
+        el,
+        "aria-expanded",
+        String(this.dropdown.opened()),
+      );
+
+      if (!this.isNativelyFocusable(el)) {
+        this.renderer.setAttribute(el, "role", "button");
+        this.renderer.setAttribute(el, "tabindex", "0");
+      }
+    });
+  }
+
+  ngAfterViewInit() {
+    this.triggerElement.set(this.resolveTriggerElement());
+  }
+
+  focus() {
+    this.triggerElement()?.focus();
   }
 
   @HostListener("click")
@@ -55,9 +92,21 @@ export class DropdownTriggerDirective {
       case "Escape":
         event.preventDefault();
         this.dropdown.hideDropdown();
-        this.host.nativeElement.focus();
+        this.focus();
         break;
     }
+  }
+
+  private resolveTriggerElement(): HTMLElement {
+    const el = this.host.nativeElement;
+    if (this.isNativelyFocusable(el)) return el;
+    return el.querySelector<HTMLElement>(FOCUSABLE_SELECTOR) ?? el;
+  }
+
+  private isNativelyFocusable(el: HTMLElement): boolean {
+    return (
+      el.tagName === "BUTTON" || (el.tagName === "A" && el.hasAttribute("href"))
+    );
   }
 
   private openAndFocusFirst() {

--- a/tedi/components/overlay/dropdown/dropdown.component.spec.ts
+++ b/tedi/components/overlay/dropdown/dropdown.component.spec.ts
@@ -11,7 +11,7 @@ import { NgxFloatUiContentComponent } from "ngx-float-ui";
 @Component({
   standalone: true,
   template: `
-    <tedi-dropdown [value]="value">
+    <tedi-dropdown [value]="value" [hideOnScroll]="hideOnScroll">
       <button tedi-dropdown-trigger>Trigger</button>
 
       <tedi-dropdown-content [dropdownRole]="role">
@@ -33,6 +33,7 @@ import { NgxFloatUiContentComponent } from "ngx-float-ui";
 class TestHostComponent {
   value = "b";
   role: "menu" | "listbox" = "listbox";
+  hideOnScroll = false;
 }
 
 @Component({
@@ -160,6 +161,53 @@ describe("DropdownComponent", () => {
     dropdown.toggleDropdown();
     fixture.detectChanges();
     expect(hideSpy).toHaveBeenCalled();
+  });
+
+  describe("hideOnScroll", () => {
+    it("sets up a scroll listener when opened with hideOnScroll true", () => {
+      host.hideOnScroll = true;
+      fixture.detectChanges();
+      (floatUi as any).state = false;
+
+      dropdown.showDropdown();
+
+      expect((dropdown as any).scrollListener).toBeDefined();
+    });
+
+    it("does not set up a scroll listener when hideOnScroll is false", () => {
+      host.hideOnScroll = false;
+      fixture.detectChanges();
+      (floatUi as any).state = false;
+
+      dropdown.showDropdown();
+
+      expect((dropdown as any).scrollListener).toBeUndefined();
+    });
+
+    it("hides the dropdown on scroll when hideOnScroll is true", () => {
+      host.hideOnScroll = true;
+      fixture.detectChanges();
+      (floatUi as any).state = false;
+      dropdown.showDropdown();
+
+      const hideSpy = jest.spyOn(dropdown, "hideDropdown");
+      (floatUi as any).state = true;
+      document.dispatchEvent(new Event("scroll"));
+
+      expect(hideSpy).toHaveBeenCalled();
+      expect((dropdown as any).scrollListener).toBeUndefined();
+    });
+
+    it("cleans up the scroll listener on destroy", () => {
+      host.hideOnScroll = true;
+      fixture.detectChanges();
+      (floatUi as any).state = false;
+      dropdown.showDropdown();
+
+      fixture.destroy();
+
+      expect((dropdown as any).scrollListener).toBeUndefined();
+    });
   });
 
   it("focusFirstItem() should focus first enabled item", () => {

--- a/tedi/components/overlay/dropdown/dropdown.component.spec.ts
+++ b/tedi/components/overlay/dropdown/dropdown.component.spec.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { Component, ViewEncapsulation } from "@angular/core";
-import { ComponentFixture, TestBed } from "@angular/core/testing";
+import {
+  ComponentFixture,
+  TestBed,
+  fakeAsync,
+  tick,
+} from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { DropdownComponent } from "./dropdown.component";
 import { DropdownTriggerDirective } from "./dropdown-trigger/dropdown-trigger.directive";
@@ -381,6 +386,111 @@ describe("DropdownComponent", () => {
     });
   });
 
+  describe("handleFocusOut()", () => {
+    it("should return early when dropdown is closed (state=false)", () => {
+      (floatUi as any).state = false;
+
+      const hideSpy = jest.spyOn(dropdown, "hideDropdown");
+
+      dropdown.handleFocusOut({
+        target: document.createElement("div"),
+      } as unknown as FocusEvent);
+
+      expect(hideSpy).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when focus moves inside the trigger element", () => {
+      (floatUi as any).state = true;
+
+      const hideSpy = jest.spyOn(dropdown, "hideDropdown");
+
+      dropdown.handleFocusOut({
+        target: dropdown.dropdownTrigger()!.host.nativeElement,
+      } as unknown as FocusEvent);
+
+      expect(hideSpy).not.toHaveBeenCalled();
+    });
+
+    it("should do nothing when focus moves inside the content element", () => {
+      (floatUi as any).state = true;
+
+      const hideSpy = jest.spyOn(dropdown, "hideDropdown");
+
+      dropdown.handleFocusOut({
+        target: dropdown.floatUiComponent().elRef.nativeElement,
+      } as unknown as FocusEvent);
+
+      expect(hideSpy).not.toHaveBeenCalled();
+    });
+
+    it("should hide dropdown without refocusing trigger when focus leaves (e.g. Tab)", () => {
+      (floatUi as any).state = true;
+
+      const hideSpy = jest.spyOn(dropdown, "hideDropdown");
+      const focusSpy = jest.spyOn(
+        dropdown.dropdownTrigger()!.host.nativeElement,
+        "focus",
+      );
+
+      dropdown.handleFocusOut({
+        target: document.createElement("div"),
+      } as unknown as FocusEvent);
+
+      expect(hideSpy).toHaveBeenCalled();
+      expect(focusSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("tabOutOfDropdown()", () => {
+    let before: HTMLButtonElement;
+    let after: HTMLButtonElement;
+
+    beforeEach(() => {
+      document.body.appendChild(fixture.nativeElement);
+      before = document.createElement("button");
+      after = document.createElement("button");
+      document.body.insertBefore(before, fixture.nativeElement);
+      document.body.appendChild(after);
+      (floatUi as any).state = true;
+    });
+
+    afterEach(() => {
+      before.remove();
+      after.remove();
+      fixture.nativeElement.remove();
+    });
+
+    it("Tab closes the dropdown and focuses the element after the trigger", fakeAsync(() => {
+      const hideSpy = jest.spyOn(dropdown, "hideDropdown");
+
+      dropdown.tabOutOfDropdown(false);
+      tick();
+
+      expect(hideSpy).toHaveBeenCalled();
+      expect(document.activeElement).toBe(after);
+    }));
+
+    it("Shift+Tab closes the dropdown and focuses the element before the trigger", fakeAsync(() => {
+      const hideSpy = jest.spyOn(dropdown, "hideDropdown");
+
+      dropdown.tabOutOfDropdown(true);
+      tick();
+
+      expect(hideSpy).toHaveBeenCalled();
+      expect(document.activeElement).toBe(before);
+    }));
+
+    it("excludes dropdown content from the tab target so focus never re-enters the menu", fakeAsync(() => {
+      after.remove();
+
+      dropdown.tabOutOfDropdown(false);
+      tick();
+
+      const items = getItems();
+      expect(items).not.toContain(document.activeElement);
+    }));
+  });
+
   describe("setActiveToSelectedOrFirst()", () => {
     it("should activate the selected item when it exists and is enabled", () => {
       host.value = "b";
@@ -531,6 +641,26 @@ describe("DropdownComponent", () => {
 
       expect(hideSpy).toHaveBeenCalled();
       expect(focusSpy).toHaveBeenCalled();
+    });
+
+    it("keydown: Tab calls dropdown.tabOutOfDropdown(false)", () => {
+      const spy = jest.spyOn(dropdown, "tabOutOfDropdown");
+
+      itemA.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab" }));
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledWith(false);
+    });
+
+    it("keydown: Shift+Tab calls dropdown.tabOutOfDropdown(true)", () => {
+      const spy = jest.spyOn(dropdown, "tabOutOfDropdown");
+
+      itemA.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Tab", shiftKey: true }),
+      );
+      fixture.detectChanges();
+
+      expect(spy).toHaveBeenCalledWith(true);
     });
 
     it("keydown: disabled item should preventDefault and NOT process", () => {

--- a/tedi/components/overlay/dropdown/dropdown.component.spec.ts
+++ b/tedi/components/overlay/dropdown/dropdown.component.spec.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Component } from "@angular/core";
+import { Component, ViewEncapsulation } from "@angular/core";
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { By } from "@angular/platform-browser";
 import { DropdownComponent } from "./dropdown.component";
@@ -34,6 +34,35 @@ class TestHostComponent {
   value = "b";
   role: "menu" | "listbox" = "listbox";
 }
+
+@Component({
+  selector: "app-button",
+  standalone: true,
+  template: `<button><ng-content /></button>`,
+  encapsulation: ViewEncapsulation.None,
+})
+class MockButtonComponent {}
+
+@Component({
+  standalone: true,
+  template: `
+    <tedi-dropdown>
+      <app-button tedi-dropdown-trigger>Trigger</app-button>
+
+      <tedi-dropdown-content>
+        <li tedi-dropdown-item value="a">Item A</li>
+      </tedi-dropdown-content>
+    </tedi-dropdown>
+  `,
+  imports: [
+    DropdownComponent,
+    DropdownTriggerDirective,
+    DropdownContentComponent,
+    DropdownItemComponent,
+    MockButtonComponent,
+  ],
+})
+class WrappingButtonHostComponent {}
 
 describe("DropdownComponent", () => {
   let fixture: ComponentFixture<TestHostComponent>;
@@ -561,6 +590,71 @@ describe("DropdownComponent", () => {
       expect(trigger.getAttribute("aria-expanded")).toBe("false");
       expect(trigger.getAttribute("role")).toBeNull();
       expect(trigger.getAttribute("tabindex")).toBeNull();
+    });
+  });
+
+  describe("DropdownTriggerDirective on a wrapping button component", () => {
+    let wrappedFixture: ComponentFixture<WrappingButtonHostComponent>;
+    let wrappedDropdown: DropdownComponent;
+    let wrapperEl: HTMLElement;
+    let innerButton: HTMLButtonElement;
+
+    beforeEach(() => {
+      wrappedFixture = TestBed.createComponent(WrappingButtonHostComponent);
+      wrappedFixture.detectChanges();
+
+      wrappedDropdown = wrappedFixture.debugElement.query(
+        By.directive(DropdownComponent),
+      ).componentInstance as DropdownComponent;
+
+      wrapperEl = wrappedFixture.nativeElement.querySelector(
+        "[tedi-dropdown-trigger]",
+      ) as HTMLElement;
+      innerButton = wrapperEl.querySelector("button") as HTMLButtonElement;
+    });
+
+    it("applies ARIA/role/tabindex to the inner button, not the wrapper", () => {
+      expect(wrapperEl.tagName).toBe("APP-BUTTON");
+
+      expect(innerButton.getAttribute("aria-haspopup")).toBe("menu");
+      expect(innerButton.getAttribute("aria-expanded")).toBe("false");
+      expect(innerButton.getAttribute("aria-controls")).toBe(
+        wrappedDropdown.containerId(),
+      );
+      expect(innerButton.getAttribute("id")).toBe(
+        `${wrappedDropdown.containerId()}_trigger`,
+      );
+
+      expect(innerButton.getAttribute("role")).toBeNull();
+      expect(innerButton.getAttribute("tabindex")).toBeNull();
+    });
+
+    it("does not turn the wrapper into a second tab stop", () => {
+      expect(wrapperEl.getAttribute("role")).toBeNull();
+      expect(wrapperEl.getAttribute("tabindex")).toBeNull();
+      expect(wrapperEl.getAttribute("aria-expanded")).toBeNull();
+    });
+
+    it("keeps aria-expanded in sync on the inner button", () => {
+      const wrappedFloatUi = wrappedDropdown.floatUiComponent() as any;
+
+      wrappedFloatUi.state = false;
+      wrappedDropdown.showDropdown();
+      wrappedFixture.detectChanges();
+      expect(innerButton.getAttribute("aria-expanded")).toBe("true");
+
+      wrappedFloatUi.state = true;
+      wrappedDropdown.hideDropdown();
+      wrappedFixture.detectChanges();
+      expect(innerButton.getAttribute("aria-expanded")).toBe("false");
+    });
+
+    it("focus() targets the inner button", () => {
+      const focusSpy = jest.spyOn(innerButton, "focus");
+
+      wrappedDropdown.dropdownTrigger().focus();
+
+      expect(focusSpy).toHaveBeenCalled();
     });
   });
 });

--- a/tedi/components/overlay/dropdown/dropdown.component.ts
+++ b/tedi/components/overlay/dropdown/dropdown.component.ts
@@ -6,6 +6,7 @@ import {
   viewChild,
   contentChild,
   signal,
+  computed,
   AfterContentChecked,
   OnDestroy,
   inject,
@@ -70,6 +71,7 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
   readonly containerId = signal("");
   readonly isContentHovered = signal(false);
   readonly floatUiDisplay = signal<"inline" | "block">("inline");
+  readonly opened = computed(() => this.floatUiDisplay() === "block");
 
   private readonly platformId = inject(PLATFORM_ID);
 
@@ -155,7 +157,7 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
 
     if (!clickedInside) {
       this.hideDropdown();
-      triggerEl.focus();
+      this.dropdownTrigger().focus();
     }
   };
 

--- a/tedi/components/overlay/dropdown/dropdown.component.ts
+++ b/tedi/components/overlay/dropdown/dropdown.component.ts
@@ -12,6 +12,7 @@ import {
   inject,
   PLATFORM_ID,
   model,
+  Renderer2,
 } from "@angular/core";
 import {
   NgxFloatUiContentComponent,
@@ -20,7 +21,7 @@ import {
 } from "ngx-float-ui";
 import { DropdownTriggerDirective } from "./dropdown-trigger/dropdown-trigger.directive";
 import { DropdownContentComponent } from "./dropdown-content/dropdown-content.component";
-import { isPlatformBrowser } from "@angular/common";
+import { DOCUMENT, isPlatformBrowser } from "@angular/common";
 import { DROPDOWN_API } from "./dropdown.tokens";
 
 export type DropdownPosition = `${NgxFloatUiPlacements}`;
@@ -63,6 +64,12 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
    */
   readonly appendTo = input("");
 
+  /**
+   * Does the dropdown hide when the page scrolls?
+   * @default false
+   */
+  readonly hideOnScroll = input(false);
+
   readonly dropdownTrigger = contentChild.required(DropdownTriggerDirective);
   readonly dropdownContent = contentChild.required(DropdownContentComponent);
   readonly floatUiComponent = viewChild.required(NgxFloatUiContentComponent);
@@ -74,6 +81,9 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
   readonly opened = computed(() => this.floatUiDisplay() === "block");
 
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly document = inject(DOCUMENT);
+  private readonly renderer = inject(Renderer2);
+  private scrollListener?: () => void;
 
   constructor() {
     if (isPlatformBrowser(this.platformId)) {
@@ -89,6 +99,7 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
         true,
       );
     }
+    this.cleanupScrollListener();
   }
 
   ngAfterContentChecked(): void {
@@ -123,11 +134,16 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
       );
     }
 
+    if (this.hideOnScroll()) {
+      this.setupScrollListener();
+    }
+
     setTimeout(() => this.focusActiveItem());
   }
 
   hideDropdown() {
     if (this.floatUiComponent().state) {
+      this.cleanupScrollListener();
       this.floatUiComponent().hide();
       this.floatUiDisplay.set("inline");
       this.activeIndex.set(null);
@@ -264,6 +280,28 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
         }
       }
     });
+  }
+
+  private setupScrollListener() {
+    this.cleanupScrollListener();
+
+    this.scrollListener = this.renderer.listen(
+      this.document,
+      "scroll",
+      () => {
+        if (this.floatUiComponent().state) {
+          this.hideDropdown();
+        }
+      },
+      { capture: true, passive: true },
+    );
+  }
+
+  private cleanupScrollListener() {
+    if (this.scrollListener) {
+      this.scrollListener();
+      this.scrollListener = undefined;
+    }
   }
 
   private findIndexByElement(el: HTMLLIElement): number {

--- a/tedi/components/overlay/dropdown/dropdown.component.ts
+++ b/tedi/components/overlay/dropdown/dropdown.component.ts
@@ -23,6 +23,7 @@ import { DropdownTriggerDirective } from "./dropdown-trigger/dropdown-trigger.di
 import { DropdownContentComponent } from "./dropdown-content/dropdown-content.component";
 import { DOCUMENT, isPlatformBrowser } from "@angular/common";
 import { DROPDOWN_API } from "./dropdown.tokens";
+import { getFocusableElements } from "../../../utils/elements.util";
 
 export type DropdownPosition = `${NgxFloatUiPlacements}`;
 
@@ -88,6 +89,7 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
   constructor() {
     if (isPlatformBrowser(this.platformId)) {
       document.addEventListener("pointerdown", this.handleOutsideClick, true);
+      document.addEventListener("focusin", this.handleFocusOut, true);
     }
   }
 
@@ -98,6 +100,7 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
         this.handleOutsideClick,
         true,
       );
+      document.removeEventListener("focusin", this.handleFocusOut, true);
     }
     this.cleanupScrollListener();
   }
@@ -176,6 +179,43 @@ export class DropdownComponent implements AfterContentChecked, OnDestroy {
       this.dropdownTrigger().focus();
     }
   };
+
+  handleFocusOut = (event: FocusEvent) => {
+    if (!this.floatUiComponent().state) return;
+
+    const target = event.target as HTMLElement;
+
+    const triggerEl = this.dropdownTrigger().host.nativeElement;
+    const contentEl = this.floatUiComponent().elRef
+      .nativeElement as HTMLElement;
+
+    const focusedInside =
+      triggerEl.contains(target) || contentEl.contains(target);
+
+    if (!focusedInside) {
+      this.hideDropdown();
+    }
+  };
+
+  tabOutOfDropdown(shiftKey: boolean) {
+    const triggerEl = this.dropdownTrigger().focusableElement;
+    const contentEl = this.floatUiComponent().elRef
+      .nativeElement as HTMLElement;
+
+    const focusable = getFocusableElements(this.document.body).filter(
+      (el) => !contentEl.contains(el),
+    );
+    const triggerIndex = focusable.indexOf(triggerEl);
+    const next = shiftKey
+      ? focusable[triggerIndex - 1]
+      : focusable[triggerIndex + 1];
+
+    this.hideDropdown();
+
+    if (next) {
+      setTimeout(() => next.focus());
+    }
+  }
 
   focusFirstItem() {
     const items = this.dropdownContent().items();

--- a/tedi/components/overlay/dropdown/dropdown.stories.ts
+++ b/tedi/components/overlay/dropdown/dropdown.stories.ts
@@ -1,3 +1,4 @@
+import { Component, ViewEncapsulation } from "@angular/core";
 import { type Meta, type StoryObj, moduleMetadata } from "@storybook/angular";
 import { DropdownComponent, DropdownPosition } from "./dropdown.component";
 import {
@@ -14,6 +15,15 @@ import { DropdownItemValueLabelComponent } from "./dropdown-item-value/dropdown-
 import { DropdownItemValueMetaComponent } from "./dropdown-item-value/dropdown-item-value-meta.component";
 import { ButtonComponent } from "../../buttons/button/button.component";
 import { IconComponent } from "../../base";
+
+@Component({
+  selector: "app-demo-button",
+  standalone: true,
+  imports: [ButtonComponent],
+  template: `<button tedi-button><ng-content /></button>`,
+  encapsulation: ViewEncapsulation.None,
+})
+class DemoWrappingButtonComponent {}
 
 const POSITIONS: DropdownPosition[] = [
   "auto",
@@ -53,6 +63,7 @@ export default {
         DropdownItemValueMetaComponent,
         ButtonComponent,
         IconComponent,
+        DemoWrappingButtonComponent,
       ],
     }),
   ],
@@ -107,7 +118,7 @@ export default {
         defaultValue: { summary: "menu" },
       },
     },
-    ariaHasPopup: {
+    ariaHaspopup: {
       control: "radio",
       options: ["menu", "listbox", "true"],
       description:
@@ -160,7 +171,7 @@ export default {
 type Story = StoryObj<
   DropdownComponent & {
     dropdownRole: DropdownRole;
-    ariaHasPopup: DropdownTriggerAriaHasPopup;
+    ariaHaspopup: DropdownTriggerAriaHasPopup;
   }
 >;
 
@@ -170,13 +181,13 @@ export const Default: Story = {
     preventOverflow: true,
     appendTo: "body",
     dropdownRole: "menu",
-    ariaHasPopup: "menu",
+    ariaHaspopup: "menu",
   },
   render: (args) => ({
     props: args,
     template: `
       <tedi-dropdown [position]="position" [preventOverflow]="preventOverflow" [appendTo]="appendTo">
-        <button tedi-button tedi-dropdown-trigger [ariaHasPopup]="ariaHasPopup">
+        <button tedi-button tedi-dropdown-trigger [ariaHaspopup]="ariaHaspopup">
           Trigger
         </button>
         <tedi-dropdown-content [dropdownRole]="dropdownRole">
@@ -196,13 +207,13 @@ export const WithMeta: Story = {
     preventOverflow: true,
     appendTo: "body",
     dropdownRole: "listbox",
-    ariaHasPopup: "listbox",
+    ariaHaspopup: "listbox",
   },
   render: (args) => ({
     props: args,
     template: `
       <tedi-dropdown [position]="position" [preventOverflow]="preventOverflow" [appendTo]="appendTo">
-        <button tedi-button tedi-dropdown-trigger [ariaHasPopup]="ariaHasPopup">
+        <button tedi-button tedi-dropdown-trigger [ariaHaspopup]="ariaHaspopup">
           Select location
         </button>
         <tedi-dropdown-content [dropdownRole]="dropdownRole">
@@ -237,13 +248,13 @@ export const WithIcons: Story = {
     preventOverflow: true,
     appendTo: "body",
     dropdownRole: "menu",
-    ariaHasPopup: "menu",
+    ariaHaspopup: "menu",
   },
   render: (args) => ({
     props: args,
     template: `
       <tedi-dropdown [position]="position" [preventOverflow]="preventOverflow" [appendTo]="appendTo">
-        <button tedi-button tedi-dropdown-trigger [ariaHasPopup]="ariaHasPopup">
+        <button tedi-button tedi-dropdown-trigger [ariaHaspopup]="ariaHaspopup">
           Actions
         </button>
         <tedi-dropdown-content [dropdownRole]="dropdownRole">
@@ -278,13 +289,13 @@ export const VerticalLayout: Story = {
     preventOverflow: true,
     appendTo: "body",
     dropdownRole: "listbox",
-    ariaHasPopup: "listbox",
+    ariaHaspopup: "listbox",
   },
   render: (args) => ({
     props: args,
     template: `
       <tedi-dropdown [position]="position" [preventOverflow]="preventOverflow" [appendTo]="appendTo">
-        <button tedi-button tedi-dropdown-trigger [ariaHasPopup]="ariaHasPopup">
+        <button tedi-button tedi-dropdown-trigger [ariaHaspopup]="ariaHaspopup">
           Select access level
         </button>
         <tedi-dropdown-content [dropdownRole]="dropdownRole">
@@ -313,6 +324,38 @@ export const VerticalLayout: Story = {
 };
 
 /**
+ * When the trigger sits on a component that wraps its own `<button>` (here
+ * `<app-demo-button>`), the directive resolves that inner button and applies the
+ * `id`, `aria-*`, focus, and keyboard handling there — keeping a single tab stop
+ * with correct screen-reader announcements.
+ */
+export const WithWrappingButtonComponent: Story = {
+  name: "Trigger on a Wrapping Button Component",
+  args: {
+    position: "bottom-start",
+    preventOverflow: true,
+    appendTo: "body",
+    dropdownRole: "menu",
+    ariaHaspopup: "menu",
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <tedi-dropdown [position]="position" [preventOverflow]="preventOverflow" [appendTo]="appendTo">
+        <app-demo-button tedi-dropdown-trigger [ariaHaspopup]="ariaHaspopup">
+          Actions
+        </app-demo-button>
+        <tedi-dropdown-content [dropdownRole]="dropdownRole">
+          <li tedi-dropdown-item>Access to health data</li>
+          <li tedi-dropdown-item [disabled]="true">Declaration of intent</li>
+          <li tedi-dropdown-item>Contacts</li>
+        </tedi-dropdown-content>
+      </tedi-dropdown>
+    `,
+  }),
+};
+
+/**
  * Items with `[closeOnSelect]="false"` keep the dropdown open after activation
  * and emit `(itemSelect)` for both mouse click and keyboard (Enter / Space).
  * Useful for multi-select checkbox menus where the user toggles several
@@ -327,7 +370,7 @@ export const KeepOpenOnSelect: Story = {
     preventOverflow: true,
     appendTo: "body",
     dropdownRole: "menu",
-    ariaHasPopup: "menu",
+    ariaHaspopup: "menu",
   },
   render: (args) => ({
     props: {
@@ -353,7 +396,7 @@ export const KeepOpenOnSelect: Story = {
     },
     template: `
       <tedi-dropdown [position]="position" [preventOverflow]="preventOverflow" [appendTo]="appendTo">
-        <button tedi-button tedi-dropdown-trigger variant="neutral" [ariaHasPopup]="ariaHasPopup">
+        <button tedi-button tedi-dropdown-trigger variant="neutral" [ariaHaspopup]="ariaHaspopup">
           <tedi-icon name="filter_list" [size]="18" color="inherit" />
           Filters
         </button>

--- a/tedi/components/overlay/dropdown/dropdown.tokens.ts
+++ b/tedi/components/overlay/dropdown/dropdown.tokens.ts
@@ -15,9 +15,15 @@ export interface DropdownApi {
   focusLastItem(): void;
   /** Close the dropdown and reset active item state. */
   hideDropdown(): void;
-  /** Reference to the dropdown trigger directive. `host` is the element the directive sits on (used for positioning and dimensions); `focus()` moves focus to the actual interactive trigger element, which may be a button nested inside a wrapping component. */
+  /** Close the dropdown and move focus to the element before (Shift+Tab) or after (Tab) the trigger in document tab order, so tabbing exits the menu as if it weren't there. */
+  tabOutOfDropdown(shiftKey: boolean): void;
+  /** Reference to the dropdown trigger directive. `host` is the element the directive sits on (used for positioning and dimensions); `focus()` moves focus to the actual interactive trigger element, which may be a button nested inside a wrapping component; `focusableElement` is that same interactive element. */
   dropdownTrigger():
-    | { host: { nativeElement: HTMLElement }; focus(): void }
+    | {
+        host: { nativeElement: HTMLElement };
+        focus(): void;
+        focusableElement: HTMLElement;
+      }
     | undefined;
 }
 

--- a/tedi/components/overlay/dropdown/dropdown.tokens.ts
+++ b/tedi/components/overlay/dropdown/dropdown.tokens.ts
@@ -15,8 +15,10 @@ export interface DropdownApi {
   focusLastItem(): void;
   /** Close the dropdown and reset active item state. */
   hideDropdown(): void;
-  /** Reference to the dropdown trigger directive. Used to read trigger dimensions and return focus. */
-  dropdownTrigger(): { host: { nativeElement: HTMLElement } } | undefined;
+  /** Reference to the dropdown trigger directive. `host` is the element the directive sits on (used for positioning and dimensions); `focus()` moves focus to the actual interactive trigger element, which may be a button nested inside a wrapping component. */
+  dropdownTrigger():
+    | { host: { nativeElement: HTMLElement }; focus(): void }
+    | undefined;
 }
 
 export const DROPDOWN_API = new InjectionToken<DropdownApi>("DropdownApi");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved focus behavior when closing dropdowns (Escape, selection, outside click) so trigger regains focus reliably.

* **New Features**
  * Added optional hideOnScroll input — dropdowns can auto-close on page scroll.
  * Support for using wrapper components that internally host a native button as dropdown triggers.

* **Refactor**
  * Accessibility: ARIA attributes and focus target now track the actual interactive element.

* **Tests**
  * Updated tests to cover wrapping triggers, ARIA sync, and scroll-hide behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->