### PR TITLE
feat(ellipsis): new tedi-ready component #472

### DIFF
--- a/skills/tedi-angular/references/components.md
+++ b/skills/tedi-angular/references/components.md
@@ -955,6 +955,20 @@ Wrapper that joins filters into a connected button group with collapsed borders 
 **Row inputs:** `cols`, `minColWidth`, `justifyItems`, `alignItems`, `gap`, `gapX`, `gapY` + responsive breakpoints
 **Col inputs:** `width` (1-12), `justifySelf`, `alignSelf` + responsive breakpoints
 
+### Ellipsis
+**Selector:** `tedi-ellipsis`
+**Inputs:**
+- `lineClamp: number = 2` — maximum lines before truncating (end position only)
+- `tooltip: boolean = true` — show hover/focus tooltip with full text when truncated
+- `position: 'start' | 'end' = 'end'` — `'end'` = trailing multi-line clamp; `'start'` = leading single-line
+
+```html
+<tedi-ellipsis style="max-width:200px">Long content that overflows...</tedi-ellipsis>
+
+<!-- Leading ellipsis (single-line) -->
+<tedi-ellipsis [position]="'start'" style="max-width:200px">/users/tehiK/tedi/angular/src/lib/components/helpers/ellipsis/ellipsis.component.ts</tedi-ellipsis>
+```
+
 ### Separator
 **Selector:** `tedi-separator`
 **Inputs:**
@@ -1413,12 +1427,16 @@ The `[(open)]` binding approach is deprecated. Use `ModalService.open()` for new
 - `loading: boolean = false`
 - `closable: boolean = false`
 - `type: TagType = "primary"`
+- `ellipsis: TagEllipsis = false` — `false | "start" | "end"`. When set (and the tag is width-constrained), truncates the label to a single line with an ellipsis at that end and reveals the full label in a tooltip on hover/focus. `false` lets the label wrap.
 **Outputs:**
 - `closed: Event`
 **Slots:** default
 
 ```html
 <tedi-tag type="primary" [closable]="true" (closed)="onRemove()">Label</tedi-tag>
+
+<!-- Truncate a long label (needs a width constraint, e.g. a max-width parent) -->
+<tedi-tag ellipsis="end" [closable]="true">A fairly long tag label</tedi-tag>
 ```
 
 ### StatusBadge

--- a/tedi/components/helpers/ellipsis/ellipsis.component.html
+++ b/tedi/components/helpers/ellipsis/ellipsis.component.html
@@ -1,0 +1,23 @@
+@if (isEllipsed() && tooltip()) {
+  <tedi-tooltip openWith="hover">
+    <tedi-tooltip-trigger class="tedi-ellipsis__trigger">
+      <ng-container [ngTemplateOutlet]="contentTpl" />
+    </tedi-tooltip-trigger>
+    <tedi-tooltip-content>{{ fullText() }}</tedi-tooltip-content>
+  </tedi-tooltip>
+} @else {
+  <ng-container [ngTemplateOutlet]="contentTpl" />
+}
+
+<ng-template #contentTpl>
+  <span class="tedi-ellipsis__wrapper">
+    <span
+      #content
+      [class]="contentClasses()"
+      [style.-webkit-line-clamp]="clampStyle()"
+      [style.line-clamp]="clampStyle()"
+    >
+      <span class="tedi-ellipsis__inner"><ng-content /></span>
+    </span>
+  </span>
+</ng-template>

--- a/tedi/components/helpers/ellipsis/ellipsis.component.scss
+++ b/tedi/components/helpers/ellipsis/ellipsis.component.scss
@@ -1,0 +1,39 @@
+.tedi-ellipsis {
+  display: block;
+  min-width: 0;
+}
+
+.tedi-ellipsis__trigger,
+.tedi-ellipsis__wrapper {
+  display: block;
+  min-width: 0;
+}
+
+.tedi-ellipsis__content {
+  display: -webkit-box;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  hyphens: auto;
+  /* stylelint-disable-next-line declaration-property-value-keyword-no-deprecated */
+  word-break: break-word;
+  -webkit-box-orient: vertical;
+
+  &--start {
+    display: block;
+    text-align: left;
+    hyphens: none;
+    word-break: normal;
+    white-space: nowrap;
+
+    // Selecting text scrolls the clipped box and breaks the leading ellipsis.
+    // The full text stays selectable through the tooltip.
+    user-select: none;
+    direction: rtl;
+
+    // Bidi-isolate the text so neutral characters (slashes, dots) at its edges
+    // keep their logical position instead of reordering under the rtl box.
+    .tedi-ellipsis__inner {
+      unicode-bidi: plaintext;
+    }
+  }
+}

--- a/tedi/components/helpers/ellipsis/ellipsis.component.spec.ts
+++ b/tedi/components/helpers/ellipsis/ellipsis.component.spec.ts
@@ -1,0 +1,177 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { EllipsisComponent } from "./index";
+
+@Component({
+  standalone: true,
+  imports: [EllipsisComponent],
+  template: `
+    <tedi-ellipsis
+      [lineClamp]="lineClamp"
+      [tooltip]="tooltip"
+      [position]="position"
+    >
+      Any inline <b>content (even bold)</b>, that is too long for the wrapper
+    </tedi-ellipsis>
+  `,
+})
+class TestHostComponent {
+  lineClamp = 2;
+  tooltip = true;
+  position: "start" | "end" = "end";
+}
+
+describe("EllipsisComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+  let ellipsisEl: HTMLElement;
+  let contentEl: HTMLElement;
+  let component: EllipsisComponent;
+
+  let resizeCallbacks: ResizeObserverCallback[];
+  const triggerResize = () =>
+    resizeCallbacks.forEach((cb) =>
+      cb([], {} as ResizeObserver),
+    );
+
+  beforeEach(() => {
+    resizeCallbacks = [];
+    global.ResizeObserver = class {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCallbacks.push(cb);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent, EllipsisComponent],
+    });
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    component = fixture.debugElement.children[0]
+      .componentInstance as EllipsisComponent;
+    fixture.detectChanges();
+    ellipsisEl = fixture.nativeElement.querySelector("tedi-ellipsis");
+    contentEl = ellipsisEl.querySelector(".tedi-ellipsis__content")!;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /** Mock the content element so an overflow measurement reports truncation. */
+  const mockTruncated = (axis: "height" | "width") => {
+    if (axis === "height") {
+      jest.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(100);
+      jest.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(50);
+    } else {
+      jest.spyOn(HTMLElement.prototype, "scrollWidth", "get").mockReturnValue(100);
+      jest.spyOn(HTMLElement.prototype, "clientWidth", "get").mockReturnValue(50);
+    }
+    triggerResize();
+    fixture.detectChanges();
+  };
+
+  it("should create", () => {
+    expect(host).toBeTruthy();
+  });
+
+  it("should render host class", () => {
+    expect(ellipsisEl.classList.contains("tedi-ellipsis")).toBe(true);
+  });
+
+  it("should render projected content", () => {
+    expect(ellipsisEl.textContent).toContain("content (even bold)");
+  });
+
+  describe("lineClamp input", () => {
+    it("should apply default lineClamp of 2 via computed style", () => {
+      expect(component.clampStyle()).toBe("2");
+    });
+
+    it("should apply custom lineClamp value through component", () => {
+      host.lineClamp = 4;
+      fixture.detectChanges();
+      expect(component.clampStyle()).toBe("4");
+    });
+  });
+
+  describe("position input", () => {
+    it("should not apply --start modifier class by default (end position)", () => {
+      expect(contentEl.classList.contains("tedi-ellipsis__content--start")).toBe(false);
+    });
+
+    it("should apply --start modifier class when position is start", () => {
+      host.position = "start";
+      fixture.detectChanges();
+      const span = ellipsisEl.querySelector(".tedi-ellipsis__content")!;
+      expect(span.classList.contains("tedi-ellipsis__content--start")).toBe(true);
+    });
+
+    it("should not set line-clamp style when position is start", () => {
+      host.position = "start";
+      fixture.detectChanges();
+      expect(component.clampStyle()).toBeNull();
+    });
+
+    it("should set line-clamp style when position is end", () => {
+      host.position = "end";
+      host.lineClamp = 3;
+      fixture.detectChanges();
+      expect(component.clampStyle()).toBe("3");
+    });
+  });
+
+  describe("truncation detection", () => {
+    it("should detect end-mode truncation via scrollHeight", () => {
+      mockTruncated("height");
+      expect(component.isEllipsed()).toBe(true);
+    });
+
+    it("should detect start-mode truncation via scrollWidth", () => {
+      host.position = "start";
+      fixture.detectChanges();
+      mockTruncated("width");
+      expect(component.isEllipsed()).toBe(true);
+    });
+
+    it("should not report truncation when content fits", () => {
+      jest.spyOn(HTMLElement.prototype, "scrollHeight", "get").mockReturnValue(50);
+      jest.spyOn(HTMLElement.prototype, "clientHeight", "get").mockReturnValue(50);
+      triggerResize();
+      fixture.detectChanges();
+      expect(component.isEllipsed()).toBe(false);
+    });
+
+    it("should populate fullText from content textContent", () => {
+      mockTruncated("height");
+      expect(component.fullText()).toContain("content (even bold)");
+    });
+  });
+
+  describe("tooltip rendering", () => {
+    it("should show tooltip wrapper when truncated and tooltip is true", () => {
+      mockTruncated("height");
+      expect(ellipsisEl.querySelector("[role=tooltip]")).toBeTruthy();
+    });
+
+    it("should not show tooltip wrapper when not truncated", () => {
+      expect(ellipsisEl.querySelector("[role=tooltip]")).toBeNull();
+    });
+
+    it("should not show tooltip wrapper when truncated but tooltip is false", () => {
+      host.tooltip = false;
+      fixture.detectChanges();
+      mockTruncated("height");
+      expect(ellipsisEl.querySelector("[role=tooltip]")).toBeNull();
+    });
+  });
+
+  describe("teardown", () => {
+    it("should disconnect ResizeObserver without error on destroy", () => {
+      expect(() => fixture.destroy()).not.toThrow();
+    });
+  });
+});

--- a/tedi/components/helpers/ellipsis/ellipsis.component.ts
+++ b/tedi/components/helpers/ellipsis/ellipsis.component.ts
@@ -1,0 +1,80 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  ViewEncapsulation,
+  computed,
+  effect,
+  input,
+  signal,
+  viewChild,
+} from "@angular/core";
+import { NgTemplateOutlet } from "@angular/common";
+import { TooltipContentComponent, TooltipTriggerComponent, TooltipComponent } from "../../overlay/tooltip/index";
+
+export type EllipsisPosition = "start" | "end";
+
+@Component({
+  standalone: true,
+  selector: "tedi-ellipsis",
+  imports: [NgTemplateOutlet, TooltipComponent, TooltipTriggerComponent, TooltipContentComponent],
+  templateUrl: "./ellipsis.component.html",
+  styleUrl: "./ellipsis.component.scss",
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    class: "tedi-ellipsis",
+  },
+})
+export class EllipsisComponent {
+  /** Maximum number of lines before truncating. End (multi-line) only. */
+  readonly lineClamp = input<number>(2);
+
+  /** Whether truncated content shows a hover/focus tooltip with full text. */
+  readonly tooltip = input<boolean>(true);
+
+  /** Ellipsis position. 'start' = leading, single-line. 'end' = trailing, multi-line. */
+  readonly position = input<EllipsisPosition>("end");
+
+  readonly content = viewChild<ElementRef<HTMLElement>>("content");
+
+  readonly isEllipsed = signal(false);
+  readonly fullText = signal("");
+
+  constructor() {
+    effect((onCleanup) => {
+      const el = this.content()?.nativeElement;
+      if (!el || typeof ResizeObserver === "undefined") return;
+
+      const measure = () => this.updateEllipsedState(el);
+      measure();
+
+      const observer = new ResizeObserver(measure);
+      observer.observe(el);
+      onCleanup(() => observer.disconnect());
+    });
+  }
+
+  readonly contentClasses = computed(() => {
+    const classes = ["tedi-ellipsis__content"];
+    if (this.position() === "start") {
+      classes.push("tedi-ellipsis__content--start");
+    }
+    return classes.join(" ");
+  });
+
+  readonly clampStyle = computed(() => {
+    if (this.position() !== "end") return null;
+    return String(this.lineClamp());
+  });
+
+  private updateEllipsedState(el: HTMLElement): void {
+    const isTruncated =
+      this.position() === "start"
+        ? el.scrollWidth > el.clientWidth
+        : el.scrollHeight > el.clientHeight;
+
+    this.isEllipsed.set(isTruncated);
+    this.fullText.set(el.textContent?.trim() ?? "");
+  }
+}

--- a/tedi/components/helpers/ellipsis/ellipsis.stories.ts
+++ b/tedi/components/helpers/ellipsis/ellipsis.stories.ts
@@ -1,0 +1,124 @@
+import { Meta, StoryObj } from "@storybook/angular";
+import { moduleMetadata } from "@storybook/angular";
+
+import { EllipsisComponent } from "./index";
+
+/**
+ * <a href="https://www.tedi.ee/1ee8444b7/p/87ef9b-ellipsis" target="_BLANK">Zeroheight ↗</a>
+ */
+export default {
+  title: "TEDI-Ready/Components/Helpers/Ellipsis",
+  component: EllipsisComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [EllipsisComponent],
+    }),
+  ],
+  parameters: {
+    status: {
+      type: ["devComponent"],
+    },
+  },
+  argTypes: {
+    lineClamp: {
+      description: "Maximum number of lines before truncating. End (multi-line) only.",
+      control: { type: "number" },
+      table: {
+        category: "inputs",
+        type: { summary: "number" },
+        defaultValue: { summary: "2" },
+      },
+    },
+    tooltip: {
+      description:
+        "Whether truncated content shows a hover/focus tooltip with full text.",
+      control: { type: "boolean" },
+      table: {
+        category: "inputs",
+        type: { summary: "boolean" },
+        defaultValue: { summary: "true" },
+      },
+    },
+    position: {
+      description:
+        "Ellipsis position. 'start' = leading, single-line. 'end' = trailing, multi-line.",
+      control: { type: "radio" },
+      options: ["start", "end"],
+      table: {
+        category: "inputs",
+        type: { summary: "'start' | 'end'" },
+        defaultValue: { summary: "'end'" },
+      },
+    },
+  },
+  args: {
+    lineClamp: 2,
+    tooltip: true,
+    position: "end",
+  },
+} as Meta<EllipsisComponent>;
+
+const CONTENT =
+  'Any inline <b>content (even bold)</b>, that is too long for the wrapper and dont fit in x number of rows';
+
+export const Default: StoryObj<EllipsisComponent> = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <div style="max-width:200px">
+        <tedi-ellipsis [lineClamp]="lineClamp" [tooltip]="tooltip" [position]="position">
+          ${CONTENT}
+        </tedi-ellipsis>
+      </div>
+    `,
+  }),
+};
+
+/**
+ * Resize the window to see that the ellipsis and tooltip appear only when content doesn't fit.
+ */
+export const ResponsiveEnd: StoryObj<EllipsisComponent> = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <tedi-ellipsis [lineClamp]="lineClamp" [tooltip]="tooltip" [position]="position">
+        ${CONTENT}
+      </tedi-ellipsis>
+    `,
+  }),
+  args: {
+    lineClamp: 1,
+  },
+};
+
+export const LeadingStart: StoryObj<EllipsisComponent> = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <div style="max-width:200px">
+        <tedi-ellipsis [lineClamp]="lineClamp" [tooltip]="tooltip" [position]="position">
+          ${CONTENT}
+        </tedi-ellipsis>
+      </div>
+    `,
+  }),
+  args: {
+    position: "start",
+  },
+};
+
+export const NoTooltip: StoryObj<EllipsisComponent> = {
+  render: (args) => ({
+    props: args,
+    template: `
+      <div style="max-width:200px">
+        <tedi-ellipsis [lineClamp]="lineClamp" [tooltip]="tooltip" [position]="position">
+          ${CONTENT}
+        </tedi-ellipsis>
+      </div>
+    `,
+  }),
+  args: {
+    tooltip: false,
+  },
+};

--- a/tedi/components/helpers/ellipsis/index.ts
+++ b/tedi/components/helpers/ellipsis/index.ts
@@ -1,0 +1,2 @@
+export { EllipsisComponent } from "./ellipsis.component";
+export type { EllipsisPosition } from "./ellipsis.component";

--- a/tedi/components/helpers/index.ts
+++ b/tedi/components/helpers/index.ts
@@ -1,4 +1,5 @@
 export * from "./empty-state";
+export * from "./ellipsis";
 export * from "./grid";
 export * from "./scroll-fade";
 export * from "./separator/separator.component";

--- a/tedi/components/helpers/scroll-fade/scroll-fade.component.ts
+++ b/tedi/components/helpers/scroll-fade/scroll-fade.component.ts
@@ -86,10 +86,12 @@ export class ScrollFadeComponent implements AfterViewInit, OnDestroy {
     const el = this.innerRef().nativeElement;
     this.updateFade(el.scrollTop, el.scrollHeight, el.clientHeight);
 
-    this.resizeObserver = new ResizeObserver(() => {
-      this.updateFade(el.scrollTop, el.scrollHeight, el.clientHeight);
-    });
-    this.resizeObserver.observe(el);
+    if (typeof ResizeObserver !== "undefined") {
+      this.resizeObserver = new ResizeObserver(() => {
+        this.updateFade(el.scrollTop, el.scrollHeight, el.clientHeight);
+      });
+      this.resizeObserver.observe(el);
+    }
   }
 
   ngOnDestroy(): void {

--- a/tedi/components/overlay/tooltip/tooltip.component.scss
+++ b/tedi/components/overlay/tooltip/tooltip.component.scss
@@ -81,6 +81,7 @@ tedi-tooltip-trigger {
   max-width: var(--tooltip-max-width);
   padding: var(--tooltip-padding-y) var(--tooltip-padding-x);
   color: var(--tooltip-text);
+  overflow-wrap: break-word;
   background: var(--tooltip-background);
   border-radius: var(--tooltip-radius);
   box-shadow: 0 1px 5px 0 var(--tedi-alpha-20, rgb(0 0 0 / 20%));

--- a/tedi/components/tags/tag/tag.component.html
+++ b/tedi/components/tags/tag/tag.component.html
@@ -5,8 +5,16 @@
 }
 
 <span class="tedi-tag__content" [attr.id]="uniqueId">
-  <ng-content />
+  @if (ellipsis()) {
+    <tedi-ellipsis [position]="ellipsisPosition()" [lineClamp]="1">
+      <ng-container [ngTemplateOutlet]="tagContent" />
+    </tedi-ellipsis>
+  } @else {
+    <ng-container [ngTemplateOutlet]="tagContent" />
+  }
 </span>
+
+<ng-template #tagContent><ng-content /></ng-template>
 
 @if (loading()) {
   <span class="tedi-tag__spinner-wrapper">

--- a/tedi/components/tags/tag/tag.component.scss
+++ b/tedi/components/tags/tag/tag.component.scss
@@ -20,6 +20,20 @@
     padding: var(--tag-default-padding-y) 0;
   }
 
+  &--ellipsis {
+    min-width: 0;
+    max-width: 100%;
+  }
+
+  &--ellipsis &__content {
+    min-width: 0;
+  }
+
+  &--ellipsis &__icon-wrapper,
+  &--ellipsis .tedi-closing-button {
+    flex-shrink: 0;
+  }
+
   &__icon-wrapper {
     line-height: var(--_line-height);
   }

--- a/tedi/components/tags/tag/tag.component.ts
+++ b/tedi/components/tags/tag/tag.component.ts
@@ -11,13 +11,23 @@ import { IconComponent } from "../../base/icon/icon.component";
 import { SpinnerComponent } from "../../loader/spinner/spinner.component";
 import { TediTranslationPipe } from "../../../services/translation/translation.pipe";
 import { ClosingButtonComponent } from "../../buttons/closing-button/closing-button.component";
+import { EllipsisComponent, EllipsisPosition } from "../../helpers/ellipsis";
+import { NgTemplateOutlet } from "@angular/common";
 import { _IdGenerator } from '@angular/cdk/a11y';
 
 export type TagType = "primary" | "secondary" | "danger";
+export type TagEllipsis = "start" | "end" | false;
 
 @Component({
   selector: "tedi-tag",
-  imports: [SpinnerComponent, IconComponent, ClosingButtonComponent, TediTranslationPipe],
+  imports: [
+    SpinnerComponent,
+    IconComponent,
+    ClosingButtonComponent,
+    TediTranslationPipe,
+    EllipsisComponent,
+    NgTemplateOutlet,
+  ],
   templateUrl: "./tag.component.html",
   styleUrl: "./tag.component.scss",
   encapsulation: ViewEncapsulation.None,
@@ -26,6 +36,7 @@ export type TagType = "primary" | "secondary" | "danger";
     "[class.tedi-tag]": "true",
     "[class.tedi-tag--loading]": "loading()",
     "[class.tedi-tag--closable]": "closable()",
+    "[class.tedi-tag--ellipsis]": "ellipsis() !== false",
     "[class]": "classes()",
   },
 })
@@ -54,6 +65,17 @@ export class TagComponent {
   type = input<TagType>("primary");
 
   /**
+   * Which end the label truncates from when it doesn't fit. `false` (default)
+   * never truncates — the label wraps and the tag keeps its full width. `end`
+   * shows an ellipsis at the end (`Long label…`); `start` shows it at the start
+   * (`…label`), which keeps the most significant part of values like dates
+   * visible. Truncation only kicks in when the tag is width-constrained, and the
+   * full label is revealed in a tooltip on hover/focus.
+   * @default false
+   */
+  ellipsis = input<TagEllipsis>(false);
+
+  /**
    * Event emitted when the close button is clicked.
    */
   closed = output<Event>();
@@ -65,6 +87,10 @@ export class TagComponent {
     }
     return classList.join(" ");
   });
+
+  ellipsisPosition = computed<EllipsisPosition>(() =>
+    this.ellipsis() === "start" ? "start" : "end",
+  );
 
   handleClose(event: Event) {
     this.closed.emit(event);

--- a/tedi/components/tags/tag/tag.stories.ts
+++ b/tedi/components/tags/tag/tag.stories.ts
@@ -21,7 +21,7 @@ export default {
   render: (props) => ({
     props,
     template: `
-      <tedi-tag [type]="type" [loading]="loading" [closable]="closable">
+      <tedi-tag [type]="type" [loading]="loading" [closable]="closable" [ellipsis]="ellipsis">
         {{content}}
       </tedi-tag>
     `,
@@ -30,6 +30,7 @@ export default {
     type: "primary",
     loading: false,
     closable: false,
+    ellipsis: false,
     content: "Tag",
   },
   argTypes: {
@@ -68,12 +69,43 @@ export default {
         category: "inputs",
       },
     },
+    ellipsis: {
+      control: "radio",
+      options: [false, "start", "end"],
+      description:
+        "Which end the label truncates from when it doesn't fit. `false` never truncates; `end` → `Long label…`; `start` → `…label`. Truncation only kicks in when the tag is width-constrained, and the full label shows in a tooltip on hover/focus.",
+      table: {
+        defaultValue: { summary: "false" },
+        type: { summary: "TagEllipsis", detail: "false \nstart \nend" },
+        category: "inputs",
+      },
+    },
   },
 } as Meta<TagComponent & { content: string }>;
 
 type Story = StoryObj<TagComponent & { content: string }>;
 
 export const Default: Story = {};
+
+export const Ellipsis: Story = {
+  render: () => ({
+    template: `
+      <div style="display: flex; flex-direction: column; gap: 0.5rem; width: 7rem;">
+        <tedi-tag [closable]="true">A fairly long tag label that wraps</tedi-tag>
+        <tedi-tag [closable]="true" ellipsis="end">A fairly long tag label, end</tedi-tag>
+        <tedi-tag [closable]="true" ellipsis="start">start, a fairly long tag label</tedi-tag>
+      </div>
+    `,
+  }),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When width-constrained, `ellipsis` truncates the label (the close button stays fixed) and reveals the full text in a tooltip on hover/focus. `false` never truncates — the label wraps; `end` cuts the end; `start` cuts the start.",
+      },
+    },
+  },
+};
 
 export const Primary: Story = {
   render: (props) => ({


### PR DESCRIPTION
* feat(tag): added ellipsis support #472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `tedi-ellipsis` component for truncating text with optional tooltip on hover/focus.
  * Added ellipsis support to `tedi-tag` with configurable start/end truncation modes.

* **Bug Fixes**
  * Fixed ResizeObserver compatibility for environments without native support.

* **Documentation**
  * Added `tedi-ellipsis` component reference with selector, inputs, and usage examples.
  * Updated `tedi-tag` documentation with ellipsis input details and truncation examples.

* **Style**
  * Enhanced tooltip text wrapping behavior for long content.

* **Tests**
  * Added comprehensive unit test suite for ellipsis component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->