### PR TITLE
feat(card,card-button,timeline-card): new tedi-ready components #453

### DIFF
--- a/community/components/cards/card/card-colors.directive.ts
+++ b/community/components/cards/card/card-colors.directive.ts
@@ -20,6 +20,9 @@ export type CardColors =
   | "neutral-primary"
   | "neutral-secondary";
 
+/**
+ * @deprecated Use background and border inputs on TEDI-ready Card components instead. This directive will be removed from future versions.
+ */
 @Directive({
   standalone: true,
   host: {

--- a/community/components/cards/card/card-content/card-content.component.ts
+++ b/community/components/cards/card/card-content/card-content.component.ts
@@ -8,6 +8,9 @@ import {
 import { CardColorsDirective } from "../card-colors.directive";
 import { CardPaddingDirective } from "../card-padding.directive";
 
+/**
+ * @deprecated Use CardContent from TEDI-ready instead. This component will be removed from future versions.
+ */
 @Component({
   selector: "tedi-card-content",
   standalone: true,

--- a/community/components/cards/card/card-header/card-header.component.ts
+++ b/community/components/cards/card/card-header/card-header.component.ts
@@ -15,6 +15,9 @@ export type CardHeaderVariant =
   | "brand"
   | "brand-dark";
 
+/**
+ * @deprecated Use CardHeader from TEDI-ready instead. This component will be removed from future versions.
+ */
 @Component({
   selector: "tedi-card-header, [tedi-card-header]",
   standalone: true,

--- a/community/components/cards/card/card-padding.directive.ts
+++ b/community/components/cards/card/card-padding.directive.ts
@@ -23,6 +23,9 @@ const getPaddingClasses = (padding: CardPadding) => {
   }
 };
 
+/**
+ * @deprecated Use the padding input on TEDI-ready Card components instead. This directive will be removed from future versions.
+ */
 @Directive({
   standalone: true,
   host: {

--- a/community/components/cards/card/card-row/card-row.component.ts
+++ b/community/components/cards/card/card-row/card-row.component.ts
@@ -6,6 +6,9 @@ import {
   ViewEncapsulation,
 } from "@angular/core";
 
+/**
+ * @deprecated Use CardRow from TEDI-ready instead. This component will be removed from future versions.
+ */
 @Component({
   selector: "tedi-card-row",
   standalone: true,

--- a/community/components/cards/card/card.component.ts
+++ b/community/components/cards/card/card.component.ts
@@ -11,6 +11,9 @@ import { CardPaddingDirective } from "./card-padding.directive";
 export type CardSpacing = "xs" | "sm" | "md" | "lg" | "none";
 export type CardAccentBorder = "info" | "success" | "warning" | "danger";
 
+/**
+ * @deprecated Use Card from TEDI-ready instead. This component will be removed from future versions.
+ */
 @Component({
   selector: "tedi-card",
   standalone: true,

--- a/community/components/cards/card/stories/card.stories.ts
+++ b/community/components/cards/card/stories/card.stories.ts
@@ -29,6 +29,11 @@ export default {
     CardHeaderComponent,
     CardContentComponent,
   },
+  parameters: {
+    status: {
+      type: ["existsInTediReady", "deprecated"],
+    },
+  },
   args: {
     spacing: "md",
   },

--- a/skills/tedi-angular/references/components.md
+++ b/skills/tedi-angular/references/components.md
@@ -45,6 +45,29 @@ All components are standalone (`standalone: true`), use `ChangeDetectionStrategy
 <button tedi-button variant="secondary" size="small">Small</button>
 ```
 
+### CardButton
+**Selector:** `a[tedi-card-button]` or `button[tedi-card-button]`
+**Slots:** `tedi-card` only (other content is not projected) — the card may use any of its blocks (content, rows, icon cells)
+
+Interactive wrapper around a `tedi-card`: the host element provides semantics (anchor for href/routerLink navigation, button for actions and the disabled state) and applies hover/active/focus/disabled states to the card inside. Icon cells turn brand-colored on hover/active. Do not place other interactive elements inside.
+
+```html
+<a tedi-card-button routerLink="/toetused">
+  <tedi-card>
+    <tedi-card-row>
+      <tedi-card-icon><tedi-icon name="euro_symbol" /></tedi-card-icon>
+      <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+        <div>
+          <p tedi-text modifiers="bold">Isiku toetused</p>
+          <p tedi-text modifiers="small" color="secondary">Toetused mis on isikule ette nähtud</p>
+        </div>
+        <tedi-icon name="arrow_right_alt" color="secondary" />
+      </tedi-card-content>
+    </tedi-card-row>
+  </tedi-card>
+</a>
+```
+
 ### ClosingButton
 **Selector:** `button[tedi-closing-button]`
 **Inputs:**
@@ -170,6 +193,84 @@ For non-clickable headers with custom actions (the toggle stays visible at the s
 ```
 
 ## Content
+
+### Card
+**Selector:** `tedi-card`
+**Inputs:**
+- `background: CardBackground` — default background for child blocks ("primary", "secondary", "tertiary", "accent", "brand-primary"…"brand-quaternary", "danger/success/info/warning/neutral-primary/-secondary")
+- `padding: CardPadding` — default padding for child blocks; rem number (0–3) or `{vertical, horizontal}` / `{top, right, bottom, left}` object
+- `borderRadius: CardBorderRadius` — `false` removes all radius, or object per side/corner (`{top: false}`, `{topLeft: false}`…)
+- `borderless: boolean = false`
+- `border: CardBorderType` — background value colors the whole border; `top-`/`left-` prefix draws a 4px accent border on that side (e.g. `"left-danger-primary"`)
+- Responsive: `xs, sm, md, lg, xl, xxl: CardInputs`
+
+Composed of sub-components:
+
+```html
+<tedi-card border="left-info-primary" [padding]="1.5">
+  <tedi-card-header background="brand-primary">Title</tedi-card-header>
+  <tedi-alert variant="noSideBorders">Notification</tedi-alert>
+  <tedi-card-content>First block</tedi-card-content>
+  <tedi-separator />
+  <tedi-card-content background="secondary">Second block</tedi-card-content>
+</tedi-card>
+```
+
+All dividers are plain `tedi-separator` elements: horizontal between blocks/rows, vertical with `size="auto"` between cells inside a `tedi-card-row`. For an in-card notification place a `tedi-alert variant="noSideBorders"` directly inside the card.
+
+The card itself is non-interactive. To make a whole card clickable, wrap it in **CardButton** (`a[tedi-card-button]` / `button[tedi-card-button]`, Buttons section), which adds hover/active/focus/disabled states.
+
+### CardContent
+**Selector:** `tedi-card-content`
+**Inputs:**
+- `background: CardBackground = "primary"` — inherits from card when unset
+- `padding: CardPadding = 1` — inherits from card when unset
+- `backgroundImage: string` — image url; with `backgroundPosition`, `backgroundSize`, `backgroundRepeat`
+- `autoWidth: boolean = false` — takes only content width inside a row (icon/date cells)
+- Responsive: `xs, sm, md, lg, xl, xxl: CardContentInputs`
+
+### CardIcon
+**Selector:** `tedi-card-icon`
+**Inputs:**
+- `type: CardIconType = "default"` — "default" (secondary background, secondary icon) or "brand" (brand-primary background, white icon)
+- `size: CardIconSize = "default"` — "small" uses 0.75rem padding; pair with a 16px icon
+- Plus all CardContent inputs (`background` override, `autoWidth`, …)
+
+Top-aligned icon cell for a card row; the projected `tedi-icon` inherits the cell color:
+
+```html
+<tedi-card-row>
+  <tedi-card-icon type="brand"><tedi-icon name="monitor_heart" /></tedi-card-icon>
+  <tedi-card-content>…</tedi-card-content>
+</tedi-card-row>
+```
+
+### CardRow
+**Selector:** `tedi-card-row`
+
+Lays out `tedi-card-content` / `tedi-card-icon` cells horizontally. No inputs — dividers are plain `tedi-separator` elements:
+
+```html
+<tedi-card>
+  <tedi-card-row>
+    <tedi-card-content [autoWidth]="true">08.12.2024</tedi-card-content>
+    <tedi-separator axis="vertical" size="auto" />
+    <tedi-card-content>COVID-19</tedi-card-content>
+  </tedi-card-row>
+  <tedi-separator />
+  <tedi-card-row>
+    <tedi-card-content>Left</tedi-card-content>
+    <tedi-card-content background="secondary">Right</tedi-card-content>
+  </tedi-card-row>
+</tedi-card>
+```
+
+For a card-styled timeline use `tedi-timeline variant="card"` (Helpers section); for a decorative dotted line between cells place a vertical dotted `tedi-separator` between them.
+
+### CardHeader
+**Selector:** `tedi-card-header`
+
+Same inputs as CardContent, but `background` defaults to `"brand-primary"` and is not inherited from the card.
 
 ### Carousel
 **Selector:** `tedi-carousel`
@@ -1030,13 +1131,20 @@ Description is projected via `<ng-content>`. Actions slot is projected via `<ng-
 ### Timeline
 **Selector:** `tedi-timeline`
 **Inputs:**
-- `activeIndex: number`
+- `activeIndex: number` — items before it render as past, after it as future
+- `variant: TimelineVariant = "default"` — "card" renders each item as a bordered, padded card row inside a card frame
+- `cardPadding: TimelineCardPadding` — item padding in rems for the card variant; same values as Card padding (0 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3; default 1)
+- Sub-components: `tedi-timeline-item` (`timings: string[]`), `tedi-timeline-title`, `tedi-timeline-description`
+- Content marked with `*tediTimelineTimingsBottom` is pinned to the bottom of the timings column on desktop and rendered after the item content on mobile (e.g. a "Muudetud …" line)
 
 ```html
-<tedi-timeline [activeIndex]="1">
-  <tedi-timeline-item [timings]="['10:00']">
-    <tedi-timeline-title>Step 1</tedi-timeline-title>
-    <tedi-timeline-description>Description</tedi-timeline-description>
+<tedi-timeline variant="card" [activeIndex]="1" [cardPadding]="1">
+  <tedi-timeline-item [timings]="['11.01.2024 12:23', 'Kersti Ööviul']">
+    <p *tediTimelineTimingsBottom tedi-text modifiers="small" color="tertiary">Muudetud 08.02.2024</p>
+    <tedi-timeline-title>Suhtlus isikuga</tedi-timeline-title>
+    <tedi-collapse openText="Näita rohkem" closeText="Näita vähem">
+      <p tedi-text modifiers="small" color="secondary">Lisainfo</p>
+    </tedi-collapse>
   </tedi-timeline-item>
 </tedi-timeline>
 ```
@@ -1508,10 +1616,12 @@ Import from `@tedi-design-system/angular/community`. These are community-contrib
 ## Cards
 
 ### Accordion — **DEPRECATED** (use TEDI-Ready Accordion)
-### Card
+### Card — **DEPRECATED** (use TEDI-Ready Card)
 **Selector:** `tedi-card`
 - `borderless: boolean`, `spacing: CardSpacing = "md"`, `accentBorder: CardAccentBorder`, `selected: boolean`
 - Sub-components: `tedi-card-header`, `tedi-card-content`, `tedi-card-row`
+
+> The TEDI-Ready Card (Content section above) uses the same `tedi-card` selector but a different API (`padding` in rems instead of named `spacing`, `border` instead of `accentBorder`, plus `tedi-card-icon` and breakpoint inputs; the Community `timeline` input is replaced by `tedi-timeline variant="card"`). Do not mix imports of the two in one component.
 
 ## Form
 

--- a/tedi/components/buttons/card-button/card-button.component.html
+++ b/tedi/components/buttons/card-button/card-button.component.html
@@ -1,0 +1,1 @@
+<ng-content select="tedi-card"></ng-content>

--- a/tedi/components/buttons/card-button/card-button.component.scss
+++ b/tedi/components/buttons/card-button/card-button.component.scss
@@ -1,0 +1,82 @@
+.tedi-card-button {
+  display: block;
+  width: 100%;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+  background: none;
+  border: none;
+
+  &:hover>.tedi-card {
+    border-color: var(--button-card-hover-border);
+
+    .tedi-card-content {
+      background-color: var(--button-card-hover-background);
+    }
+
+    .tedi-icon {
+      color: var(--button-card-icon-hover);
+    }
+
+    .tedi-card-icon {
+      color: var(--general-icon-white);
+      background-color: var(--button-card-hover-icon-background);
+    }
+
+    .tedi-card-icon .tedi-icon {
+      color: inherit;
+    }
+  }
+
+  &:active>.tedi-card {
+    border-color: var(--button-card-active-border);
+
+    .tedi-card-content {
+      background-color: var(--button-card-active-background);
+    }
+
+    .tedi-icon {
+      color: var(--button-card-icon-hover);
+    }
+
+    .tedi-card-icon {
+      color: var(--general-icon-white);
+      background-color: var(--button-card-active-icon-background);
+    }
+
+    .tedi-card-icon .tedi-icon {
+      color: inherit;
+    }
+  }
+
+  &:focus-visible {
+    outline: none;
+    border-radius: var(--card-radius-rounded);
+    box-shadow:
+      0 0 0 1px var(--tedi-neutral-100),
+      0 0 0 3px var(--tedi-primary-500);
+  }
+
+  &:disabled {
+    cursor: default;
+
+    >.tedi-card {
+      color: var(--general-text-disabled);
+      border-color: var(--button-card-disabled-border);
+
+      .tedi-card-content,
+      .tedi-card-icon {
+        background-color: var(--button-card-disabled-background);
+      }
+
+      [class*="tedi-text--"],
+      .tedi-icon,
+      .tedi-card-icon {
+        color: var(--general-text-disabled);
+      }
+    }
+  }
+}

--- a/tedi/components/buttons/card-button/card-button.component.spec.ts
+++ b/tedi/components/buttons/card-button/card-button.component.spec.ts
@@ -1,0 +1,100 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BreakpointObserver } from "@angular/cdk/layout";
+import { of } from "rxjs";
+import { CardButtonComponent } from "./card-button.component";
+import { CardComponent } from "../../content/card/card.component";
+import { CardContentComponent } from "../../content/card/card-content/card-content.component";
+import { CardIconComponent } from "../../content/card/card-icon/card-icon.component";
+import { CardRowComponent } from "../../content/card/card-row/card-row.component";
+
+@Component({
+  standalone: true,
+  imports: [
+    CardButtonComponent,
+    CardComponent,
+    CardContentComponent,
+    CardIconComponent,
+    CardRowComponent,
+  ],
+  template: `
+    <a tedi-card-button href="#">
+      <span class="stray">Should not render</span>
+      <tedi-card>
+        <tedi-card-content>
+          <span class="projected">Töövõime</span>
+        </tedi-card-content>
+      </tedi-card>
+    </a>
+    <button tedi-card-button type="button" [disabled]="disabled">
+      <tedi-card>
+        <tedi-card-row>
+          <tedi-card-icon><span class="icon">€</span></tedi-card-icon>
+          <tedi-card-content>
+            <span class="projected-button">Isiku toetused</span>
+          </tedi-card-content>
+        </tedi-card-row>
+      </tedi-card>
+    </button>
+  `,
+})
+class TestHostComponent {
+  disabled = false;
+}
+
+describe("CardButtonComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        {
+          provide: BreakpointObserver,
+          useValue: {
+            observe: () =>
+              of({ matches: true, breakpoints: { "(min-width: 0px)": true } }),
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const anchor = (): HTMLAnchorElement =>
+    fixture.nativeElement.querySelector("a[tedi-card-button]");
+  const button = (): HTMLButtonElement =>
+    fixture.nativeElement.querySelector("button[tedi-card-button]");
+
+  it("should wrap a card on an anchor host", () => {
+    expect(anchor()).toBeTruthy();
+    expect(anchor().classList).toContain("tedi-card-button");
+    expect(anchor().querySelector("tedi-card .projected")?.textContent).toBe(
+      "Töövõime",
+    );
+  });
+
+  it("should wrap a card with rows and icon cells on a button host", () => {
+    expect(button()).toBeTruthy();
+    expect(button().classList).toContain("tedi-card-button");
+    expect(
+      button().querySelector("tedi-card tedi-card-row tedi-card-icon .icon"),
+    ).toBeTruthy();
+    expect(button().querySelector(".projected-button")).toBeTruthy();
+  });
+
+  it("should project only the tedi-card content", () => {
+    expect(anchor().querySelector(".stray")).toBeNull();
+    expect(anchor().querySelector("tedi-card")).toBeTruthy();
+  });
+
+  it("should support the disabled state on a button host", () => {
+    host.disabled = true;
+    fixture.detectChanges();
+    expect(button().disabled).toBe(true);
+  });
+});

--- a/tedi/components/buttons/card-button/card-button.component.ts
+++ b/tedi/components/buttons/card-button/card-button.component.ts
@@ -1,0 +1,28 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+} from "@angular/core";
+
+/**
+ * Interactive wrapper around a `tedi-card`. Apply to an anchor (with `href`
+ * or `routerLink`) for navigation or to a button for actions — the host
+ * element provides the interaction semantics and applies the hover, active,
+ * focus and disabled states to the card and its blocks inside.
+ *
+ * Only a projected `tedi-card` is rendered — other content is ignored. The
+ * card may use any card sub-components (content, rows, icon cells). Do not
+ * place other interactive elements inside.
+ */
+@Component({
+  selector: "a[tedi-card-button], button[tedi-card-button]",
+  standalone: true,
+  templateUrl: "./card-button.component.html",
+  styleUrl: "./card-button.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    class: "tedi-card-button",
+  },
+})
+export class CardButtonComponent {}

--- a/tedi/components/buttons/card-button/card-button.stories.ts
+++ b/tedi/components/buttons/card-button/card-button.stories.ts
@@ -1,0 +1,433 @@
+import { Meta, moduleMetadata, StoryObj } from "@storybook/angular";
+import { CardButtonComponent } from "./card-button.component";
+import { CardComponent } from "../../content/card/card.component";
+import { CardContentComponent } from "../../content/card/card-content/card-content.component";
+import { CardIconComponent } from "../../content/card/card-icon/card-icon.component";
+import { CardRowComponent } from "../../content/card/card-row/card-row.component";
+import { TextComponent } from "../../base/text/text.component";
+import { IconComponent } from "../../base/icon/icon.component";
+import { StatusBadgeComponent } from "../../tags/status-badge/status-badge.component";
+import { SeparatorComponent } from "../../helpers/separator/separator.component";
+import { TextGroupComponent } from "../../content/text-group/text-group.component";
+import { TextGroupLabelComponent } from "../../content/text-group/text-group-label.component";
+import { TextGroupValueComponent } from "../../content/text-group/text-group-value.component";
+import { RowComponent } from "../../helpers/grid/row/row.component";
+import { ColComponent } from "../../helpers/grid/col/col.component";
+import { VerticalSpacingDirective } from "../../../directives/vertical-spacing/vertical-spacing.directive";
+import { ShowAtDirective } from "../../../directives/show-at/show-at.directive";
+
+/**
+ * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.54.76?node-id=4620-85618&m=dev" target="_blank">Figma ↗</a>
+ *
+ * CardButton is an interactive wrapper around a `tedi-card`. The host anchor
+ * or button provides the semantics and applies hover, active, focus and
+ * disabled states to the card and its blocks inside. Any card composition
+ * works inside it — content blocks, rows and icon cells. Do not place other
+ * interactive elements inside.
+ */
+export default {
+  title: "TEDI-Ready/Components/Buttons/CardButton",
+  component: CardButtonComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        CardButtonComponent,
+        CardComponent,
+        CardContentComponent,
+        CardIconComponent,
+        CardRowComponent,
+        TextComponent,
+        IconComponent,
+        StatusBadgeComponent,
+        SeparatorComponent,
+        TextGroupComponent,
+        TextGroupLabelComponent,
+        TextGroupValueComponent,
+        RowComponent,
+        ColComponent,
+        VerticalSpacingDirective,
+        ShowAtDirective,
+      ],
+    }),
+  ],
+} as Meta<CardButtonComponent>;
+
+type Story = StoryObj<CardButtonComponent>;
+
+export const Default: Story = {
+  render: () => ({
+    template: `
+      <a tedi-card-button href="#">
+        <tedi-card>
+          <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+            <div>
+              <p tedi-text modifiers="bold">Töövõime</p>
+              <p tedi-text modifiers="small" color="secondary">Näiteks töövõimetuslehed, töövõime hindamine</p>
+            </div>
+            <tedi-icon name="arrow_right_alt" color="secondary" />
+          </tedi-card-content>
+        </tedi-card>
+      </a>
+    `,
+  }),
+};
+
+export const CardRow: Story = {
+  render: () => ({
+    template: `
+      <div [tediVerticalSpacing]="1">
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-content class="flex align-items-center gap-3">
+              <p tedi-text modifiers="bold">8:30</p>
+              <div class="flex-fill">
+                <p tedi-text modifiers="bold">Kardioloog</p>
+                <p tedi-text modifiers="small" color="secondary">Valdkond</p>
+              </div>
+              <span tedi-text color="brand" class="flex align-items-center gap-2">
+                <span *showAt="'sm'" aria-hidden="true">Broneerima</span>
+                <tedi-icon name="arrow_right_alt" color="brand" label="Broneerima" />
+              </span>
+            </tedi-card-content>
+          </tedi-card>
+        </a>
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-content class="flex align-items-center gap-3">
+              <tedi-icon name="monitor_heart" color="secondary" />
+              <div class="flex-fill">
+                <p tedi-text modifiers="bold">Kardioloog</p>
+                <p tedi-text modifiers="small" color="secondary">Valdkond</p>
+              </div>
+              <span tedi-text color="brand" class="flex align-items-center gap-2">
+                <span *showAt="'sm'" aria-hidden="true">Broneerima</span>
+                <tedi-icon name="arrow_right_alt" color="brand" label="Broneerima" />
+              </span>
+            </tedi-card-content>
+          </tedi-card>
+        </a>
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-content class="flex align-items-center gap-3">
+              <div class="flex-fill">
+                <p tedi-text modifiers="bold">Kardioloog</p>
+                <tedi-status-badge color="success" text="Kindlustatud | Tervisekassa" />
+              </div>
+              <span tedi-text color="brand" class="flex align-items-center gap-2">
+                <span *showAt="'sm'" aria-hidden="true">Broneerima</span>
+                <tedi-icon name="arrow_right_alt" color="brand" label="Broneerima" />
+              </span>
+            </tedi-card-content>
+          </tedi-card>
+        </a>
+      </div>
+    `,
+  }),
+};
+
+export const CardShortcutWithIconCard: Story = {
+  render: () => ({
+    template: `
+      <tedi-row [cols]="1" [lg]="{ cols: 3 }" [gap]="3">
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-row>
+              <tedi-card-icon>
+                <tedi-icon name="euro_symbol" />
+              </tedi-card-icon>
+              <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                <div>
+                  <p tedi-text modifiers="bold">Isiku toetused</p>
+                  <p tedi-text modifiers="small" color="secondary">Toetused mis on isikule ette nähtud</p>
+                </div>
+                <tedi-icon name="arrow_right_alt" color="secondary" />
+              </tedi-card-content>
+            </tedi-card-row>
+          </tedi-card>
+        </a>
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-row>
+              <tedi-card-icon>
+                <tedi-icon name="checklist" />
+              </tedi-card-icon>
+              <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                <div>
+                  <p tedi-text modifiers="bold">Isiku hindamised</p>
+                  <p tedi-text modifiers="small" color="secondary">Hindamised toetuste saamiseks</p>
+                </div>
+                <tedi-icon name="arrow_right_alt" color="secondary" />
+              </tedi-card-content>
+            </tedi-card-row>
+          </tedi-card>
+        </a>
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-row>
+              <tedi-card-icon>
+                <tedi-icon name="contract" />
+              </tedi-card-icon>
+              <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                <div>
+                  <p tedi-text modifiers="bold">Isiku teenused</p>
+                  <p tedi-text modifiers="small" color="secondary">Teenused mis on võimaldatud peale hinnagu andmist</p>
+                </div>
+                <tedi-icon name="arrow_right_alt" color="secondary" />
+              </tedi-card-content>
+            </tedi-card-row>
+          </tedi-card>
+        </a>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const AsButton: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Use a button host when the card triggers an action instead of navigating. Only the button host supports the disabled state.",
+      },
+    },
+  },
+  render: () => ({
+    template: `
+      <button tedi-card-button type="button">
+        <tedi-card>
+          <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+            <div>
+              <p tedi-text modifiers="bold">Töövõime</p>
+              <p tedi-text modifiers="small" color="secondary">Näiteks töövõimetuslehed, töövõime hindamine</p>
+            </div>
+            <tedi-icon name="arrow_right_alt" color="secondary" />
+          </tedi-card-content>
+        </tedi-card>
+      </button>
+    `,
+  }),
+};
+
+export const States: Story = {
+  parameters: {
+    pseudo: {
+      hover: "#Hover",
+      active: "#Active",
+      focusVisible: "#Focus",
+    },
+  },
+  render: () => ({
+    template: `
+      <tedi-row [cols]="1" [sm]="{ cols: 6 }" [gapY]="3" alignItems="center">
+        <tedi-col width="1">
+          <p tedi-text modifiers="bold">Default</p>
+        </tedi-col>
+        <tedi-col width="5">
+          <a tedi-card-button id="Default" href="#">
+            <tedi-card>
+              <tedi-card-row>
+                <tedi-card-icon><tedi-icon name="euro_symbol" /></tedi-card-icon>
+                <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                  <div>
+                    <p tedi-text modifiers="bold">Isiku toetused</p>
+                    <p tedi-text modifiers="small" color="secondary">Toetused mis on isikule ette nähtud</p>
+                  </div>
+                  <tedi-icon name="arrow_right_alt" color="secondary" />
+                </tedi-card-content>
+              </tedi-card-row>
+            </tedi-card>
+          </a>
+        </tedi-col>
+        <tedi-col width="1">
+          <p tedi-text modifiers="bold">Hover</p>
+        </tedi-col>
+        <tedi-col width="5">
+          <a tedi-card-button id="Hover" href="#">
+            <tedi-card>
+              <tedi-card-row>
+                <tedi-card-icon><tedi-icon name="euro_symbol" /></tedi-card-icon>
+                <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                  <div>
+                    <p tedi-text modifiers="bold">Isiku toetused</p>
+                    <p tedi-text modifiers="small" color="secondary">Toetused mis on isikule ette nähtud</p>
+                  </div>
+                  <tedi-icon name="arrow_right_alt" color="secondary" />
+                </tedi-card-content>
+              </tedi-card-row>
+            </tedi-card>
+          </a>
+        </tedi-col>
+        <tedi-col width="1">
+          <p tedi-text modifiers="bold">Active</p>
+        </tedi-col>
+        <tedi-col width="5">
+          <a tedi-card-button id="Active" href="#">
+            <tedi-card>
+              <tedi-card-row>
+                <tedi-card-icon><tedi-icon name="euro_symbol" /></tedi-card-icon>
+                <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                  <div>
+                    <p tedi-text modifiers="bold">Isiku toetused</p>
+                    <p tedi-text modifiers="small" color="secondary">Toetused mis on isikule ette nähtud</p>
+                  </div>
+                  <tedi-icon name="arrow_right_alt" color="secondary" />
+                </tedi-card-content>
+              </tedi-card-row>
+            </tedi-card>
+          </a>
+        </tedi-col>
+        <tedi-col width="1">
+          <p tedi-text modifiers="bold">Focus</p>
+        </tedi-col>
+        <tedi-col width="5">
+          <a tedi-card-button id="Focus" href="#">
+            <tedi-card>
+              <tedi-card-row>
+                <tedi-card-icon><tedi-icon name="euro_symbol" /></tedi-card-icon>
+                <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                  <div>
+                    <p tedi-text modifiers="bold">Isiku toetused</p>
+                    <p tedi-text modifiers="small" color="secondary">Toetused mis on isikule ette nähtud</p>
+                  </div>
+                  <tedi-icon name="arrow_right_alt" color="secondary" />
+                </tedi-card-content>
+              </tedi-card-row>
+            </tedi-card>
+          </a>
+        </tedi-col>
+        <tedi-col width="1">
+          <p tedi-text modifiers="bold">Disabled</p>
+        </tedi-col>
+        <tedi-col width="5">
+          <button tedi-card-button id="Disabled" disabled>
+            <tedi-card>
+              <tedi-card-row>
+                <tedi-card-icon><tedi-icon name="euro_symbol" /></tedi-card-icon>
+                <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+                  <div>
+                    <p tedi-text modifiers="bold">Isiku toetused</p>
+                    <p tedi-text modifiers="small" color="secondary">Toetused mis on isikule ette nähtud</p>
+                  </div>
+                  <tedi-icon name="arrow_right_alt" color="secondary" />
+                </tedi-card-content>
+              </tedi-card-row>
+            </tedi-card>
+          </button>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const TabCard: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Mobile navigation pattern: full-width tab cards with a brand title, description and a centered arrow.",
+      },
+    },
+  },
+  render: () => ({
+    template: `
+      <div [tediVerticalSpacing]="1">
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+              <div>
+                <h4 tedi-text color="brand">Minu andmed</h4>
+                <p tedi-text modifiers="small" color="secondary">Isikuandmed ja sinu perearstiga seotud info.</p>
+              </div>
+              <tedi-icon name="arrow_right_alt" color="secondary" />
+            </tedi-card-content>
+          </tedi-card>
+        </a>
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+              <div>
+                <h4 tedi-text color="brand">Minu retseptid</h4>
+                <p tedi-text modifiers="small" color="secondary">Retseptid ja meditsiiniseadme kaardid.</p>
+              </div>
+              <tedi-icon name="arrow_right_alt" color="secondary" />
+            </tedi-card-content>
+          </tedi-card>
+        </a>
+        <a tedi-card-button href="#">
+          <tedi-card>
+            <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+              <div>
+                <h4 tedi-text color="brand">Minu vaktsineerimised</h4>
+                <p tedi-text modifiers="small" color="secondary">Vaktsineerimiste ülevaade ja immuniseerimiskava.</p>
+              </div>
+              <tedi-icon name="arrow_right_alt" color="secondary" />
+            </tedi-card-content>
+          </tedi-card>
+        </a>
+      </div>
+    `,
+  }),
+};
+
+export const ComplexCard: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Any card composition works inside the wrapper — rows, icon cells, separators, text groups and badges. Avoid interactive elements inside.",
+      },
+    },
+  },
+  render: () => ({
+    template: `
+      <a tedi-card-button href="#">
+        <tedi-card>
+          <tedi-card-row>
+            <tedi-card-icon>
+              <tedi-icon name="prescriptions" />
+            </tedi-card-icon>
+            <tedi-card-content class="flex flex-wrap align-items-center justify-content-between gap-3">
+              <div>
+                <p tedi-text modifiers="bold">Amlodipiin 50mg</p>
+                <p tedi-text modifiers="small" color="secondary">Amlodipin-rathiopharm 50mg</p>
+              </div>
+              <div class="flex flex-wrap align-items-center gap-3">
+                <tedi-status-badge color="success" variant="bordered" text="Kehtiv" />
+                <p tedi-text modifiers="small" color="secondary">Kehtiv kuni 12.05.2024</p>
+                <tedi-icon name="arrow_right_alt" color="secondary" />
+              </div>
+            </tedi-card-content>
+          </tedi-card-row>
+          <tedi-separator />
+          <tedi-card-row>
+            <tedi-card-icon>
+              <tedi-icon name="info" />
+            </tedi-card-icon>
+            <tedi-card-content>
+              <tedi-row [cols]="1" [md]="{ cols: 3 }" [gap]="1">
+                <tedi-col>
+                  <tedi-text-group type="vertical">
+                    <tedi-text-group-label>Toimeaine</tedi-text-group-label>
+                    <tedi-text-group-value>Amlodipiin</tedi-text-group-value>
+                  </tedi-text-group>
+                </tedi-col>
+                <tedi-col>
+                  <tedi-text-group type="vertical">
+                    <tedi-text-group-label>Kogus</tedi-text-group-label>
+                    <tedi-text-group-value>30 tk</tedi-text-group-value>
+                  </tedi-text-group>
+                </tedi-col>
+                <tedi-col>
+                  <tedi-text-group type="vertical">
+                    <tedi-text-group-label>Välja ostmata</tedi-text-group-label>
+                    <tedi-text-group-value>5 / 6 retsepti</tedi-text-group-value>
+                  </tedi-text-group>
+                </tedi-col>
+              </tedi-row>
+            </tedi-card-content>
+          </tedi-card-row>
+        </tedi-card>
+      </a>
+    `,
+  }),
+};

--- a/tedi/components/buttons/card-button/index.ts
+++ b/tedi/components/buttons/card-button/index.ts
@@ -1,0 +1,1 @@
+export * from "./card-button.component";

--- a/tedi/components/buttons/index.ts
+++ b/tedi/components/buttons/index.ts
@@ -1,4 +1,5 @@
 export * from "./button/button.component";
+export * from "./card-button";
 export * from "./info-button/info-button.component";
 export * from "./collapse/collapse.component";
 export * from "./collapse-button/collapse-button.component";

--- a/tedi/components/content/card/_card-mixins.scss
+++ b/tedi/components/content/card/_card-mixins.scss
@@ -1,0 +1,44 @@
+$card-colors: (
+  "accent": "--card-background-accent",
+  "brand-primary": "--card-background-brand-primary",
+  "brand-secondary": "--card-background-brand-secondary",
+  "brand-tertiary": "--card-background-brand-tertiary",
+  "brand-quaternary": "--card-background-brand-quaternary",
+  "primary": "--card-background-primary",
+  "secondary": "--card-background-secondary",
+  "tertiary": "--card-background-tertiary",
+  "info-primary": "--general-status-info-background-light",
+  "info-secondary": "--general-status-info-background-dark",
+  "neutral-primary": "--general-status-neutral-background-light",
+  "neutral-secondary": "--general-status-neutral-background-dark",
+  "success-primary": "--card-background-success",
+  "success-secondary": "--general-status-success-background-secondary",
+  "danger-primary": "--general-status-danger-background-primary",
+  "danger-secondary": "--general-status-danger-background-secondary",
+  "warning-primary": "--general-status-warning-background-light",
+  "warning-secondary": "--general-status-warning-background-dark",
+);
+
+@mixin card-padding {
+  padding: var(--card-content-padding-top) var(--card-content-padding-right)
+    var(--card-content-padding-bottom) var(--card-content-padding-left);
+}
+
+@mixin card-backgrounds($block) {
+  @each $name, $color-var in $card-colors {
+    .#{$block}--background--#{$name} {
+      background-color: var(#{$color-var});
+    }
+  }
+
+  .#{$block}--background--brand-primary,
+  .#{$block}--background--brand-secondary {
+    color: var(--general-text-white);
+  }
+}
+
+@mixin card-cell($block) {
+  .#{$block}--auto-width {
+    flex: 0 0 auto;
+  }
+}

--- a/tedi/components/content/card/card-content/card-content.component.html
+++ b/tedi/components/content/card/card-content/card-content.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/tedi/components/content/card/card-content/card-content.component.scss
+++ b/tedi/components/content/card/card-content/card-content.component.scss
@@ -1,0 +1,12 @@
+@use "../card-mixins";
+
+@include card-mixins.card-backgrounds("tedi-card-content");
+
+.tedi-card-content {
+  display: block;
+  flex: 1 1 1px;
+
+  @include card-mixins.card-padding;
+}
+
+@include card-mixins.card-cell("tedi-card-content");

--- a/tedi/components/content/card/card-content/card-content.component.spec.ts
+++ b/tedi/components/content/card/card-content/card-content.component.spec.ts
@@ -1,0 +1,184 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BreakpointObserver } from "@angular/cdk/layout";
+import { of } from "rxjs";
+import { CardComponent } from "../card.component";
+import { CardContentComponent } from "./card-content.component";
+import { CardBackground, CardPadding } from "../card.utils";
+
+@Component({
+  standalone: true,
+  imports: [CardContentComponent],
+  template: `
+    <tedi-card-content
+      [background]="background"
+      [padding]="padding"
+      [backgroundImage]="backgroundImage"
+      [backgroundPosition]="backgroundPosition"
+      [backgroundSize]="backgroundSize"
+      [backgroundRepeat]="backgroundRepeat"
+    >
+      <span class="projected">Content</span>
+    </tedi-card-content>
+  `,
+})
+class TestHostComponent {
+  background?: CardBackground;
+  padding?: CardPadding;
+  backgroundImage?: string;
+  backgroundPosition?: string;
+  backgroundSize?: string;
+  backgroundRepeat?: string;
+}
+
+@Component({
+  standalone: true,
+  imports: [CardComponent, CardContentComponent],
+  template: `
+    <tedi-card [background]="cardBackground" [padding]="cardPadding">
+      <tedi-card-content [background]="background" [padding]="padding">
+        Content
+      </tedi-card-content>
+    </tedi-card>
+  `,
+})
+class TestCardHostComponent {
+  cardBackground?: CardBackground;
+  cardPadding?: CardPadding;
+  background?: CardBackground;
+  padding?: CardPadding;
+}
+
+const breakpointObserverMock = {
+  provide: BreakpointObserver,
+  useValue: {
+    observe: () =>
+      of({ matches: true, breakpoints: { "(min-width: 0px)": true } }),
+  },
+};
+
+describe("CardContentComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [breakpointObserverMock],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const contentElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector("tedi-card-content");
+
+  it("should create with default classes and padding", () => {
+    expect(contentElement().classList).toContain("tedi-card-content");
+    expect(contentElement().classList).toContain(
+      "tedi-card-content--background--primary",
+    );
+    expect(
+      contentElement().style.getPropertyValue("--card-content-padding-top"),
+    ).toBe("1rem");
+    expect(fixture.nativeElement.querySelector(".projected")).toBeTruthy();
+  });
+
+  it("should apply number padding to all sides", () => {
+    host.padding = 1.5;
+    fixture.detectChanges();
+    const style = contentElement().style;
+    expect(style.getPropertyValue("--card-content-padding-top")).toBe("1.5rem");
+    expect(style.getPropertyValue("--card-content-padding-right")).toBe("1.5rem");
+    expect(style.getPropertyValue("--card-content-padding-bottom")).toBe("1.5rem");
+    expect(style.getPropertyValue("--card-content-padding-left")).toBe("1.5rem");
+  });
+
+  it("should apply vertical and horizontal padding", () => {
+    host.padding = { vertical: 0.5, horizontal: 2 };
+    fixture.detectChanges();
+    const style = contentElement().style;
+    expect(style.getPropertyValue("--card-content-padding-top")).toBe("0.5rem");
+    expect(style.getPropertyValue("--card-content-padding-bottom")).toBe("0.5rem");
+    expect(style.getPropertyValue("--card-content-padding-left")).toBe("2rem");
+    expect(style.getPropertyValue("--card-content-padding-right")).toBe("2rem");
+  });
+
+  it("should apply per-side padding and default missing sides to 0", () => {
+    host.padding = { top: 1, left: 0.75 };
+    fixture.detectChanges();
+    const style = contentElement().style;
+    expect(style.getPropertyValue("--card-content-padding-top")).toBe("1rem");
+    expect(style.getPropertyValue("--card-content-padding-left")).toBe("0.75rem");
+    expect(style.getPropertyValue("--card-content-padding-right")).toBe("0rem");
+    expect(style.getPropertyValue("--card-content-padding-bottom")).toBe("0rem");
+  });
+
+  it("should apply background modifier class", () => {
+    host.background = "danger-secondary";
+    fixture.detectChanges();
+    expect(contentElement().classList).toContain(
+      "tedi-card-content--background--danger-secondary",
+    );
+  });
+
+  it("should apply background image styles", () => {
+    host.backgroundImage = "image.png";
+    host.backgroundPosition = "center";
+    host.backgroundSize = "cover";
+    host.backgroundRepeat = "no-repeat";
+    fixture.detectChanges();
+    const style = contentElement().style;
+    expect(style.backgroundImage).toBe("url(image.png)");
+    expect(style.backgroundPosition).toBe("center");
+    expect(style.backgroundSize).toBe("cover");
+    expect(style.backgroundRepeat).toBe("no-repeat");
+  });
+});
+
+describe("CardContentComponent inside CardComponent", () => {
+  let fixture: ComponentFixture<TestCardHostComponent>;
+  let host: TestCardHostComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestCardHostComponent],
+      providers: [breakpointObserverMock],
+    });
+
+    fixture = TestBed.createComponent(TestCardHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const contentElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector("tedi-card-content");
+
+  it("should inherit background and padding from card", () => {
+    host.cardBackground = "accent";
+    host.cardPadding = 0.5;
+    fixture.detectChanges();
+    expect(contentElement().classList).toContain(
+      "tedi-card-content--background--accent",
+    );
+    expect(
+      contentElement().style.getPropertyValue("--card-content-padding-top"),
+    ).toBe("0.5rem");
+  });
+
+  it("should prioritize own inputs over card defaults", () => {
+    host.cardBackground = "accent";
+    host.cardPadding = 0.5;
+    host.background = "secondary";
+    host.padding = 2;
+    fixture.detectChanges();
+    expect(contentElement().classList).toContain(
+      "tedi-card-content--background--secondary",
+    );
+    expect(
+      contentElement().style.getPropertyValue("--card-content-padding-top"),
+    ).toBe("2rem");
+  });
+});

--- a/tedi/components/content/card/card-content/card-content.component.ts
+++ b/tedi/components/content/card/card-content/card-content.component.ts
@@ -1,0 +1,165 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  ViewEncapsulation,
+} from "@angular/core";
+import {
+  BreakpointInputs,
+  BreakpointService,
+} from "../../../../services/breakpoint/breakpoint.service";
+import { CardComponent } from "../card.component";
+import {
+  CardBackground,
+  CardPadding,
+  getPaddingCssVariables,
+} from "../card.utils";
+
+export type CardContentInputs = {
+  background?: CardBackground;
+  padding?: CardPadding;
+  backgroundImage?: string;
+  backgroundPosition?: string;
+  backgroundSize?: string;
+  backgroundRepeat?: string;
+  autoWidth?: boolean;
+};
+
+/**
+ * Content block of a card. Inherits unset `background` and `padding`
+ * from the parent `tedi-card`.
+ */
+@Component({
+  selector: "tedi-card-content",
+  standalone: true,
+  templateUrl: "./card-content.component.html",
+  styleUrl: "./card-content.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    "[class]": "classes()",
+    "[style]": "styles()",
+  },
+})
+export class CardContentComponent
+  implements BreakpointInputs<CardContentInputs>
+{
+  /**
+   * Background color.
+   * @default primary
+   */
+  background = input<CardBackground>();
+  /**
+   * Content padding.
+   * Value is either a predefined number in rems or an object of
+   * vertical/horizontal or top/right/bottom/left number values in rems.
+   * @default 1
+   */
+  padding = input<CardPadding>();
+  /**
+   * Background image url.
+   */
+  backgroundImage = input<string>();
+  /**
+   * Background position for the image.
+   */
+  backgroundPosition = input<string>();
+  /**
+   * Background size for the image.
+   */
+  backgroundSize = input<string>();
+  /**
+   * Background repeat for the image.
+   */
+  backgroundRepeat = input<string>();
+  /**
+   * Takes only as much width as its content needs instead of growing.
+   * Useful for icon or date cells inside `tedi-card-row`.
+   * @default false
+   */
+  autoWidth = input<boolean | undefined>(false);
+
+  xs = input<CardContentInputs>();
+  sm = input<CardContentInputs>();
+  md = input<CardContentInputs>();
+  lg = input<CardContentInputs>();
+  xl = input<CardContentInputs>();
+  xxl = input<CardContentInputs>();
+
+  protected blockClass = "tedi-card-content";
+  protected defaultBackground: CardBackground = "primary";
+
+  private breakpointService = inject(BreakpointService);
+  private card = inject(CardComponent, { optional: true });
+
+  breakpointInputs = computed(() => {
+    return this.breakpointService.getBreakpointInputs<CardContentInputs>({
+      background: this.background(),
+      padding: this.padding(),
+      backgroundImage: this.backgroundImage(),
+      backgroundPosition: this.backgroundPosition(),
+      backgroundSize: this.backgroundSize(),
+      backgroundRepeat: this.backgroundRepeat(),
+      autoWidth: this.autoWidth(),
+
+      xs: this.xs(),
+      sm: this.sm(),
+      md: this.md(),
+      lg: this.lg(),
+      xl: this.xl(),
+      xxl: this.xxl(),
+    });
+  });
+
+  classes = computed(() => {
+    const { background, autoWidth } = this.breakpointInputs();
+    const resolvedBackground =
+      background ?? this.inheritedBackground() ?? this.defaultBackground;
+    const classList = [
+      this.blockClass,
+      `${this.blockClass}--background--${resolvedBackground}`,
+    ];
+
+    if (autoWidth) {
+      classList.push(`${this.blockClass}--auto-width`);
+    }
+
+    return classList.join(" ");
+  });
+
+  styles = computed(() => {
+    const { padding, backgroundImage, backgroundPosition, backgroundSize, backgroundRepeat } =
+      this.breakpointInputs();
+    const resolvedPadding =
+      padding ?? this.card?.breakpointInputs().padding ?? this.defaultPadding();
+    const styles: Record<string, string> = getPaddingCssVariables(resolvedPadding);
+
+    if (backgroundImage) {
+      styles["background-image"] = `url(${backgroundImage})`;
+    }
+
+    if (backgroundPosition) {
+      styles["background-position"] = backgroundPosition;
+    }
+
+    if (backgroundSize) {
+      styles["background-size"] = backgroundSize;
+    }
+
+    if (backgroundRepeat) {
+      styles["background-repeat"] = backgroundRepeat;
+    }
+
+    return styles;
+  });
+
+  protected inheritedBackground(): CardBackground | undefined {
+    return this.card?.breakpointInputs().background;
+  }
+
+  protected defaultPadding(): CardPadding {
+    return 1;
+  }
+}

--- a/tedi/components/content/card/card-content/index.ts
+++ b/tedi/components/content/card/card-content/index.ts
@@ -1,0 +1,1 @@
+export * from "./card-content.component";

--- a/tedi/components/content/card/card-header/card-header.component.html
+++ b/tedi/components/content/card/card-header/card-header.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/tedi/components/content/card/card-header/card-header.component.scss
+++ b/tedi/components/content/card/card-header/card-header.component.scss
@@ -1,0 +1,17 @@
+@use "../card-mixins";
+
+@include card-mixins.card-backgrounds("tedi-card-header");
+
+.tedi-card-header {
+  z-index: 1;
+  display: block;
+  flex: 0 0 auto;
+
+  @include card-mixins.card-padding;
+
+  @media print {
+    color: var(--general-text-primary);
+    background: var(--card-background-primary);
+    border-bottom: 1px solid var(--card-border-primary);
+  }
+}

--- a/tedi/components/content/card/card-header/card-header.component.spec.ts
+++ b/tedi/components/content/card/card-header/card-header.component.spec.ts
@@ -1,0 +1,93 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BreakpointObserver } from "@angular/cdk/layout";
+import { of } from "rxjs";
+import { CardComponent } from "../card.component";
+import { CardHeaderComponent } from "./card-header.component";
+import { CardBackground, CardPadding } from "../card.utils";
+
+@Component({
+  standalone: true,
+  imports: [CardComponent, CardHeaderComponent],
+  template: `
+    <tedi-card [background]="cardBackground" [padding]="cardPadding">
+      <tedi-card-header [background]="background" [padding]="padding">
+        <span class="projected">Header</span>
+      </tedi-card-header>
+    </tedi-card>
+  `,
+})
+class TestHostComponent {
+  cardBackground?: CardBackground;
+  cardPadding?: CardPadding;
+  background?: CardBackground;
+  padding?: CardPadding;
+}
+
+describe("CardHeaderComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        {
+          provide: BreakpointObserver,
+          useValue: {
+            observe: () =>
+              of({ matches: true, breakpoints: { "(min-width: 0px)": true } }),
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const headerElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector("tedi-card-header");
+
+  it("should create with brand-primary background by default", () => {
+    expect(headerElement().classList).toContain("tedi-card-header");
+    expect(headerElement().classList).toContain(
+      "tedi-card-header--background--brand-primary",
+    );
+    expect(fixture.nativeElement.querySelector(".projected")).toBeTruthy();
+  });
+
+  it("should override default background with own input", () => {
+    host.background = "secondary";
+    fixture.detectChanges();
+    expect(headerElement().classList).toContain(
+      "tedi-card-header--background--secondary",
+    );
+    expect(headerElement().classList).not.toContain(
+      "tedi-card-header--background--brand-primary",
+    );
+  });
+
+  it("should not inherit background from card", () => {
+    host.cardBackground = "accent";
+    fixture.detectChanges();
+    expect(headerElement().classList).toContain(
+      "tedi-card-header--background--brand-primary",
+    );
+  });
+
+  it("should inherit padding from card", () => {
+    host.cardPadding = 0.75;
+    fixture.detectChanges();
+    expect(
+      headerElement().style.getPropertyValue("--card-content-padding-top"),
+    ).toBe("0.75rem");
+  });
+
+  it("should have default padding of 1rem", () => {
+    expect(
+      headerElement().style.getPropertyValue("--card-content-padding-top"),
+    ).toBe("1rem");
+  });
+});

--- a/tedi/components/content/card/card-header/card-header.component.ts
+++ b/tedi/components/content/card/card-header/card-header.component.ts
@@ -1,0 +1,32 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+} from "@angular/core";
+import { CardContentComponent } from "../card-content/card-content.component";
+import { CardBackground } from "../card.utils";
+
+/**
+ * Header block of a card. Same API as `tedi-card-content`, but defaults to
+ * the brand-primary background and does not inherit background from the card.
+ */
+@Component({
+  selector: "tedi-card-header",
+  standalone: true,
+  templateUrl: "./card-header.component.html",
+  styleUrl: "./card-header.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    "[class]": "classes()",
+    "[style]": "styles()",
+  },
+})
+export class CardHeaderComponent extends CardContentComponent {
+  protected override blockClass = "tedi-card-header";
+  protected override defaultBackground: CardBackground = "brand-primary";
+
+  protected override inheritedBackground(): CardBackground | undefined {
+    return undefined;
+  }
+}

--- a/tedi/components/content/card/card-header/index.ts
+++ b/tedi/components/content/card/card-header/index.ts
@@ -1,0 +1,1 @@
+export * from "./card-header.component";

--- a/tedi/components/content/card/card-icon/card-icon.component.html
+++ b/tedi/components/content/card/card-icon/card-icon.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/tedi/components/content/card/card-icon/card-icon.component.scss
+++ b/tedi/components/content/card/card-icon/card-icon.component.scss
@@ -1,0 +1,18 @@
+@use "../card-mixins";
+
+.tedi-card-icon {
+  display: flex;
+  flex: 0 0 auto;
+  gap: var(--layout-grid-gutters-08);
+  align-items: flex-start;
+  color: var(--general-icon-secondary);
+
+  @include card-mixins.card-padding;
+
+  .tedi-icon {
+    color: inherit;
+  }
+}
+
+@include card-mixins.card-backgrounds("tedi-card-icon");
+@include card-mixins.card-cell("tedi-card-icon");

--- a/tedi/components/content/card/card-icon/card-icon.component.spec.ts
+++ b/tedi/components/content/card/card-icon/card-icon.component.spec.ts
@@ -1,0 +1,85 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BreakpointObserver } from "@angular/cdk/layout";
+import { of } from "rxjs";
+import { CardIconComponent, CardIconSize, CardIconType } from "./card-icon.component";
+import { CardBackground } from "../card.utils";
+
+@Component({
+  standalone: true,
+  imports: [CardIconComponent],
+  template: `
+    <tedi-card-icon [type]="type" [size]="size" [background]="background">
+      <span class="projected">Icon</span>
+    </tedi-card-icon>
+  `,
+})
+class TestHostComponent {
+  type: CardIconType = "default";
+  size: CardIconSize = "default";
+  background?: CardBackground;
+}
+
+describe("CardIconComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        {
+          provide: BreakpointObserver,
+          useValue: {
+            observe: () =>
+              of({ matches: true, breakpoints: { "(min-width: 0px)": true } }),
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  const iconElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector("tedi-card-icon");
+
+  it("should create with secondary background and default padding", () => {
+    expect(iconElement().classList).toContain("tedi-card-icon");
+    expect(iconElement().classList).toContain(
+      "tedi-card-icon--background--secondary",
+    );
+    expect(
+      iconElement().style.getPropertyValue("--card-content-padding-top"),
+    ).toBe("1rem");
+    expect(fixture.nativeElement.querySelector(".projected")).toBeTruthy();
+  });
+
+  it("should use brand background for brand type", () => {
+    host.type = "brand";
+    fixture.detectChanges();
+    expect(iconElement().classList).toContain(
+      "tedi-card-icon--background--brand-primary",
+    );
+  });
+
+  it("should use smaller padding for small size", () => {
+    host.size = "small";
+    fixture.detectChanges();
+    expect(
+      iconElement().style.getPropertyValue("--card-content-padding-top"),
+    ).toBe("0.75rem");
+  });
+
+  it("should prioritize explicit background over type", () => {
+    host.type = "brand";
+    host.background = "accent";
+    fixture.detectChanges();
+    expect(iconElement().classList).toContain(
+      "tedi-card-icon--background--accent",
+    );
+  });
+
+});

--- a/tedi/components/content/card/card-icon/card-icon.component.ts
+++ b/tedi/components/content/card/card-icon/card-icon.component.ts
@@ -1,0 +1,50 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  ViewEncapsulation,
+} from "@angular/core";
+import { CardContentComponent } from "../card-content/card-content.component";
+import { CardBackground, CardPadding } from "../card.utils";
+
+export type CardIconType = "default" | "brand";
+export type CardIconSize = "default" | "small";
+
+/**
+ * Icon cell for a card row. The projected icon is aligned to the top of the
+ * cell and inherits the cell color. Pair the small size with a 16px icon.
+ */
+@Component({
+  selector: "tedi-card-icon",
+  standalone: true,
+  templateUrl: "./card-icon.component.html",
+  styleUrl: "./card-icon.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    "[class]": "classes()",
+    "[style]": "styles()",
+  },
+})
+export class CardIconComponent extends CardContentComponent {
+  /**
+   * Visual type of the icon cell.
+   * @default default
+   */
+  type = input<CardIconType>("default");
+  /**
+   * Size of the icon cell.
+   * @default default
+   */
+  size = input<CardIconSize>("default");
+
+  protected override blockClass = "tedi-card-icon";
+
+  protected override inheritedBackground(): CardBackground | undefined {
+    return this.type() === "brand" ? "brand-primary" : "secondary";
+  }
+
+  protected override defaultPadding(): CardPadding {
+    return this.size() === "small" ? 0.75 : 1;
+  }
+}

--- a/tedi/components/content/card/card-icon/index.ts
+++ b/tedi/components/content/card/card-icon/index.ts
@@ -1,0 +1,1 @@
+export * from "./card-icon.component";

--- a/tedi/components/content/card/card-row/card-row.component.html
+++ b/tedi/components/content/card/card-row/card-row.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/tedi/components/content/card/card-row/card-row.component.scss
+++ b/tedi/components/content/card/card-row/card-row.component.scss
@@ -1,0 +1,19 @@
+.tedi-card-row {
+  display: flex;
+}
+
+.tedi-card > .tedi-card-row:first-child > :first-child {
+  border-start-start-radius: var(--card-radius-rounded);
+}
+
+.tedi-card > .tedi-card-row:first-child > :last-child {
+  border-start-end-radius: var(--card-radius-rounded);
+}
+
+.tedi-card > .tedi-card-row:last-child > :first-child {
+  border-end-start-radius: var(--card-radius-rounded);
+}
+
+.tedi-card > .tedi-card-row:last-child > :last-child {
+  border-end-end-radius: var(--card-radius-rounded);
+}

--- a/tedi/components/content/card/card-row/card-row.component.spec.ts
+++ b/tedi/components/content/card/card-row/card-row.component.spec.ts
@@ -1,0 +1,59 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BreakpointObserver } from "@angular/cdk/layout";
+import { of } from "rxjs";
+import { CardComponent } from "../card.component";
+import { CardContentComponent } from "../card-content/card-content.component";
+import { CardRowComponent } from "./card-row.component";
+
+@Component({
+  standalone: true,
+  imports: [CardComponent, CardContentComponent, CardRowComponent],
+  template: `
+    <tedi-card>
+      <tedi-card-row>
+        <tedi-card-content [autoWidth]="true">Left</tedi-card-content>
+        <tedi-card-content>Right</tedi-card-content>
+      </tedi-card-row>
+      <tedi-card-row>
+        <tedi-card-content>Cell</tedi-card-content>
+      </tedi-card-row>
+    </tedi-card>
+  `,
+})
+class TestHostComponent {}
+
+describe("CardRowComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        {
+          provide: BreakpointObserver,
+          useValue: {
+            observe: () =>
+              of({ matches: true, breakpoints: { "(min-width: 0px)": true } }),
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    fixture.detectChanges();
+  });
+
+  const rowElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector("tedi-card-row");
+
+  it("should create with row class and project content blocks", () => {
+    expect(rowElement().classList).toContain("tedi-card-row");
+    expect(rowElement().querySelectorAll("tedi-card-content")).toHaveLength(2);
+  });
+
+  it("should apply auto-width class on content blocks", () => {
+    const content = rowElement().querySelector("tedi-card-content");
+    expect(content?.classList).toContain("tedi-card-content--auto-width");
+  });
+});

--- a/tedi/components/content/card/card-row/card-row.component.ts
+++ b/tedi/components/content/card/card-row/card-row.component.ts
@@ -1,0 +1,23 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ViewEncapsulation,
+} from "@angular/core";
+
+/**
+ * Lays out card content cells horizontally inside a card.
+ * Place a `tedi-separator` between cells (vertical, `size="auto"`) or
+ * between rows (horizontal) to draw dividers.
+ */
+@Component({
+  selector: "tedi-card-row",
+  standalone: true,
+  templateUrl: "./card-row.component.html",
+  styleUrl: "./card-row.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    "[class.tedi-card-row]": "true",
+  },
+})
+export class CardRowComponent {}

--- a/tedi/components/content/card/card-row/index.ts
+++ b/tedi/components/content/card/card-row/index.ts
@@ -1,0 +1,1 @@
+export * from "./card-row.component";

--- a/tedi/components/content/card/card.component.html
+++ b/tedi/components/content/card/card.component.html
@@ -1,0 +1,1 @@
+<ng-content></ng-content>

--- a/tedi/components/content/card/card.component.scss
+++ b/tedi/components/content/card/card.component.scss
@@ -1,0 +1,95 @@
+@use "./card-mixins";
+
+.tedi-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--card-border-primary);
+  border-radius: var(--card-radius-rounded);
+
+  > :first-child {
+    border-start-start-radius: var(--card-radius-rounded);
+    border-start-end-radius: var(--card-radius-rounded);
+  }
+
+  > :last-child {
+    border-end-start-radius: var(--card-radius-rounded);
+    border-end-end-radius: var(--card-radius-rounded);
+  }
+
+  @each $name, $color-var in card-mixins.$card-colors {
+    &--border--#{$name} {
+      border-color: var(#{$color-var});
+
+      --card-border-color: var(#{$color-var});
+    }
+  }
+
+  &--border-left {
+    border-top-color: var(--card-border-primary);
+    border-right-color: var(--card-border-primary);
+    border-bottom-color: var(--card-border-primary);
+    border-left: 4px solid var(--card-border-color);
+
+    > :first-child,
+    > :last-child {
+      border-start-start-radius: 0;
+      border-end-start-radius: 0;
+    }
+  }
+
+  &--border-top {
+    border-top: 4px solid var(--card-border-color);
+    border-right-color: var(--card-border-primary);
+    border-bottom-color: var(--card-border-primary);
+    border-left-color: var(--card-border-primary);
+
+    > :first-child {
+      border-start-start-radius: 0;
+      border-start-end-radius: 0;
+    }
+  }
+
+  &--borderless {
+    border: none;
+  }
+
+  &--no-radius-tl {
+    border-top-left-radius: 0;
+
+    > :first-child {
+      border-start-start-radius: 0;
+    }
+  }
+
+  &--no-radius-tr {
+    border-top-right-radius: 0;
+
+    > :first-child {
+      border-start-end-radius: 0;
+    }
+  }
+
+  &--no-radius-br {
+    border-bottom-right-radius: 0;
+
+    > :last-child {
+      border-end-end-radius: 0;
+    }
+  }
+
+  &--no-radius-bl {
+    border-bottom-left-radius: 0;
+
+    > :last-child {
+      border-end-start-radius: 0;
+    }
+  }
+
+  &--border-left,
+  &--border-top {
+    @media print {
+      border-color: var(--general-border-secondary);
+    }
+  }
+}

--- a/tedi/components/content/card/card.component.spec.ts
+++ b/tedi/components/content/card/card.component.spec.ts
@@ -1,0 +1,165 @@
+import { Component } from "@angular/core";
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { BreakpointObserver } from "@angular/cdk/layout";
+import { of } from "rxjs";
+import { CardComponent, CardInputs } from "./card.component";
+import { CardBorderRadius, CardBorderType } from "./card.utils";
+
+@Component({
+  standalone: true,
+  imports: [CardComponent],
+  template: `
+    <tedi-card
+      [borderless]="borderless"
+      [border]="border"
+      [borderRadius]="borderRadius"
+      [md]="md"
+    >
+      <span class="projected">Content</span>
+    </tedi-card>
+  `,
+})
+class TestHostComponent {
+  borderless = false;
+  border?: CardBorderType;
+  borderRadius?: CardBorderRadius;
+  md?: CardInputs;
+}
+
+describe("CardComponent", () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let host: TestHostComponent;
+
+  const createComponent = (minWidthMatches: number[] = [0]) => {
+    TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        {
+          provide: BreakpointObserver,
+          useValue: {
+            observe: () =>
+              of({
+                matches: true,
+                breakpoints: Object.fromEntries(
+                  minWidthMatches.map((width) => [
+                    `(min-width: ${width}px)`,
+                    true,
+                  ]),
+                ),
+              }),
+          },
+        },
+      ],
+    });
+
+    fixture = TestBed.createComponent(TestHostComponent);
+    host = fixture.componentInstance;
+    fixture.detectChanges();
+  };
+
+  const cardElement = (): HTMLElement =>
+    fixture.nativeElement.querySelector("tedi-card");
+
+  it("should create and project content", () => {
+    createComponent();
+    expect(cardElement()).toBeTruthy();
+    expect(cardElement().classList).toContain("tedi-card");
+    expect(fixture.nativeElement.querySelector(".projected")).toBeTruthy();
+  });
+
+  it("should not have modifier classes by default", () => {
+    createComponent();
+    const classes = Array.from(cardElement().classList);
+    expect(classes).toEqual(["tedi-card"]);
+  });
+
+  it("should apply borderless class", () => {
+    createComponent();
+    host.borderless = true;
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--borderless");
+  });
+
+  it("should apply border color without placement", () => {
+    createComponent();
+    host.border = "accent";
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--border--accent");
+    expect(cardElement().classList).not.toContain("tedi-card--border-top");
+    expect(cardElement().classList).not.toContain("tedi-card--border-left");
+  });
+
+  it("should apply left border placement with color", () => {
+    createComponent();
+    host.border = "left-danger-primary";
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--border-left");
+    expect(cardElement().classList).toContain(
+      "tedi-card--border--danger-primary",
+    );
+  });
+
+  it("should apply top border placement with color", () => {
+    createComponent();
+    host.border = "top-info-primary";
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--border-top");
+    expect(cardElement().classList).toContain(
+      "tedi-card--border--info-primary",
+    );
+  });
+
+  it("should remove all corner radiuses with borderRadius false", () => {
+    createComponent();
+    host.borderRadius = false;
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--no-radius-tl");
+    expect(cardElement().classList).toContain("tedi-card--no-radius-tr");
+    expect(cardElement().classList).toContain("tedi-card--no-radius-br");
+    expect(cardElement().classList).toContain("tedi-card--no-radius-bl");
+  });
+
+  it("should remove corners of a side", () => {
+    createComponent();
+    host.borderRadius = { top: false };
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--no-radius-tl");
+    expect(cardElement().classList).toContain("tedi-card--no-radius-tr");
+    expect(cardElement().classList).not.toContain("tedi-card--no-radius-br");
+    expect(cardElement().classList).not.toContain("tedi-card--no-radius-bl");
+  });
+
+  it("should prioritize corner overrides over side values", () => {
+    createComponent();
+    host.borderRadius = { bottom: false, bottomRight: true };
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--no-radius-bl");
+    expect(cardElement().classList).not.toContain("tedi-card--no-radius-br");
+  });
+
+  it("should remove a single corner", () => {
+    createComponent();
+    host.borderRadius = { topLeft: false };
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--no-radius-tl");
+    expect(cardElement().classList).not.toContain("tedi-card--no-radius-tr");
+  });
+
+  it("should apply breakpoint overrides at matching breakpoint", () => {
+    createComponent([0, 576, 768]);
+    host.md = { borderless: true, border: "left-success-primary" };
+    fixture.detectChanges();
+    expect(cardElement().classList).toContain("tedi-card--borderless");
+    expect(cardElement().classList).toContain("tedi-card--border-left");
+    expect(cardElement().classList).toContain(
+      "tedi-card--border--success-primary",
+    );
+  });
+
+  it("should not apply breakpoint overrides below their breakpoint", () => {
+    createComponent([0]);
+    host.md = { borderless: true };
+    fixture.detectChanges();
+    expect(cardElement().classList).not.toContain("tedi-card--borderless");
+  });
+});

--- a/tedi/components/content/card/card.component.ts
+++ b/tedi/components/content/card/card.component.ts
@@ -1,0 +1,138 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+  input,
+  ViewEncapsulation,
+} from "@angular/core";
+import {
+  BreakpointInputs,
+  BreakpointService,
+} from "../../../services/breakpoint/breakpoint.service";
+import {
+  CardBackground,
+  CardBorderRadius,
+  CardBorderType,
+  CardPadding,
+  getCardBorderPlacementColor,
+  resolveCardBorderRadius,
+} from "./card.utils";
+
+export type CardInputs = {
+  background?: CardBackground;
+  padding?: CardPadding;
+  borderRadius?: CardBorderRadius;
+  borderless?: boolean;
+  border?: CardBorderType;
+};
+
+/**
+ * Card is a container for grouping related content. Compose it from
+ * `tedi-card-header`, `tedi-card-content` and `tedi-card-notification` blocks.
+ * `background` and `padding` set here act as defaults for all child blocks.
+ */
+@Component({
+  selector: "tedi-card",
+  standalone: true,
+  templateUrl: "./card.component.html",
+  styleUrl: "./card.component.scss",
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  encapsulation: ViewEncapsulation.None,
+  host: {
+    "[class]": "classes()",
+  },
+})
+export class CardComponent implements BreakpointInputs<CardInputs> {
+  /**
+   * Default background color for child content blocks.
+   */
+  background = input<CardBackground>();
+  /**
+   * Default padding for child content blocks.
+   * Value is either a predefined number in rems or an object of
+   * vertical/horizontal or top/right/bottom/left number values in rems.
+   */
+  padding = input<CardPadding>();
+  /**
+   * Controls card border radius.
+   * Accepts `false` to remove all radius or an object to control
+   * sides or individual corners. Corner values take precedence over sides.
+   */
+  borderRadius = input<CardBorderRadius>();
+  /**
+   * Removes border from card.
+   * @default false
+   */
+  borderless = input<boolean | undefined>(false);
+  /**
+   * Type of border. Plain background value colors the whole border,
+   * `top-` or `left-` prefixed value draws a thick accent border on that side.
+   */
+  border = input<CardBorderType>();
+
+  xs = input<CardInputs>();
+  sm = input<CardInputs>();
+  md = input<CardInputs>();
+  lg = input<CardInputs>();
+  xl = input<CardInputs>();
+  xxl = input<CardInputs>();
+
+  private breakpointService = inject(BreakpointService);
+
+  breakpointInputs = computed(() => {
+    return this.breakpointService.getBreakpointInputs<CardInputs>({
+      background: this.background(),
+      padding: this.padding(),
+      borderRadius: this.borderRadius(),
+      borderless: this.borderless(),
+      border: this.border(),
+
+      xs: this.xs(),
+      sm: this.sm(),
+      md: this.md(),
+      lg: this.lg(),
+      xl: this.xl(),
+      xxl: this.xxl(),
+    });
+  });
+
+  classes = computed(() => {
+    const { border, borderless, borderRadius } = this.breakpointInputs();
+    const classList = ["tedi-card"];
+
+    const [placement, color] = getCardBorderPlacementColor(border);
+
+    if (placement) {
+      classList.push(`tedi-card--border-${placement}`);
+    }
+
+    if (color) {
+      classList.push(`tedi-card--border--${color}`);
+    }
+
+    if (borderless) {
+      classList.push("tedi-card--borderless");
+    }
+
+    const corners = resolveCardBorderRadius(borderRadius);
+
+    if (!corners.topLeft) {
+      classList.push("tedi-card--no-radius-tl");
+    }
+
+    if (!corners.topRight) {
+      classList.push("tedi-card--no-radius-tr");
+    }
+
+    if (!corners.bottomRight) {
+      classList.push("tedi-card--no-radius-br");
+    }
+
+    if (!corners.bottomLeft) {
+      classList.push("tedi-card--no-radius-bl");
+    }
+
+    return classList.join(" ");
+  });
+}

--- a/tedi/components/content/card/card.stories.ts
+++ b/tedi/components/content/card/card.stories.ts
@@ -1,0 +1,1189 @@
+import {
+  argsToTemplate,
+  Meta,
+  moduleMetadata,
+  StoryObj,
+} from "@storybook/angular";
+import { CardComponent } from "./card.component";
+import { CardContentComponent } from "./card-content/card-content.component";
+import { CardHeaderComponent } from "./card-header/card-header.component";
+import { CardIconComponent } from "./card-icon/card-icon.component";
+import { CardRowComponent } from "./card-row/card-row.component";
+import { CardBackground, CardBorderType } from "./card.utils";
+import { TextGroupComponent } from "../text-group/text-group.component";
+import { TextGroupLabelComponent } from "../text-group/text-group-label.component";
+import { TextGroupValueComponent } from "../text-group/text-group-value.component";
+import { TextComponent } from "../../base/text/text.component";
+import { IconComponent } from "../../base/icon/icon.component";
+import { AlertComponent } from "../../notifications/alert/alert.component";
+import { ButtonComponent } from "../../buttons/button/button.component";
+import { InfoButtonComponent } from "../../buttons/info-button/info-button.component";
+import { CollapseComponent } from "../../buttons/collapse/collapse.component";
+import { LinkComponent } from "../../navigation/link/link.component";
+import { StatusBadgeComponent } from "../../tags/status-badge/status-badge.component";
+import { SeparatorComponent } from "../../helpers/separator/separator.component";
+import { RowComponent } from "../../helpers/grid/row/row.component";
+import { ColComponent } from "../../helpers/grid/col/col.component";
+import { VerticalSpacingDirective } from "../../../directives/vertical-spacing/vertical-spacing.directive";
+
+const CARD_BACKGROUNDS: CardBackground[] = [
+  "primary",
+  "secondary",
+  "tertiary",
+  "accent",
+  "brand-primary",
+  "brand-secondary",
+  "brand-tertiary",
+  "brand-quaternary",
+  "danger-primary",
+  "danger-secondary",
+  "success-primary",
+  "success-secondary",
+  "info-primary",
+  "info-secondary",
+  "warning-primary",
+  "warning-secondary",
+  "neutral-primary",
+  "neutral-secondary",
+];
+
+const CARD_BORDERS: CardBorderType[] = [
+  ...CARD_BACKGROUNDS,
+  ...CARD_BACKGROUNDS.map((color): CardBorderType => `top-${color}`),
+  ...CARD_BACKGROUNDS.map((color): CardBorderType => `left-${color}`),
+];
+
+const CABBAGE_TEXT =
+  "Kapsas (Brassica oleracea) on rohelise, punase (lilla) või valge (kahvaturohelise) lehestikuga kaheaastane taim, mida kasvatatakse üheaastase köögiviljana selle tihedate lehtpeade saamiseks.";
+
+/**
+ * <a href="https://www.figma.com/design/jWiRIXhHRxwVdMSimKX2FF/TEDI-READY-2.53.75?node-id=4442-91315&m=dev" target="_blank">Figma ↗</a><br>
+ * <a href="https://www.tedi.ee/1ee8444b7/p/35d515-card" target="_blank">Zeroheight ↗</a>
+ */
+export default {
+  title: "TEDI-Ready/Content/Card",
+  component: CardComponent,
+  decorators: [
+    moduleMetadata({
+      imports: [
+        CardComponent,
+        CardContentComponent,
+        CardHeaderComponent,
+        AlertComponent,
+        CardIconComponent,
+        CardRowComponent,
+        TextComponent,
+        TextGroupComponent,
+        TextGroupLabelComponent,
+        TextGroupValueComponent,
+        IconComponent,
+        ButtonComponent,
+        InfoButtonComponent,
+        CollapseComponent,
+        LinkComponent,
+        StatusBadgeComponent,
+        SeparatorComponent,
+        RowComponent,
+        ColComponent,
+        VerticalSpacingDirective,
+      ],
+    }),
+  ],
+  parameters: {
+    controls: {
+      exclude: ["xs", "sm", "md", "lg", "xl", "xxl"],
+    },
+  },
+  argTypes: {
+    background: {
+      description:
+        "Default background color for child content blocks. Child blocks can override it with their own background input.",
+      control: { type: "select" },
+      options: CARD_BACKGROUNDS,
+      table: {
+        category: "inputs",
+        type: { summary: "CardBackground" },
+        defaultValue: { summary: "undefined" },
+      },
+    },
+    padding: {
+      description:
+        "Default padding for child content blocks in rems. Accepts a predefined number or an object of vertical/horizontal or top/right/bottom/left values.",
+      control: { type: "select" },
+      options: [0, 0.5, 0.75, 1, 1.5, 2, 2.5, 3],
+      table: {
+        category: "inputs",
+        type: { summary: "CardPadding" },
+        defaultValue: { summary: "1" },
+      },
+    },
+    borderRadius: {
+      description:
+        "Controls card border radius. Accepts false to remove all radius or an object to control sides or individual corners. Corner values take precedence over sides.",
+      control: { type: "object" },
+      table: {
+        category: "inputs",
+        type: { summary: "CardBorderRadius" },
+        defaultValue: { summary: "undefined" },
+      },
+    },
+    borderless: {
+      description: "Removes border from card.",
+      control: { type: "boolean" },
+      table: {
+        category: "inputs",
+        type: { summary: "boolean" },
+        defaultValue: { summary: "false" },
+      },
+    },
+    border: {
+      description:
+        "Type of border. A plain background value colors the whole border, a top- or left- prefixed value draws a thick accent border on that side.",
+      control: { type: "select" },
+      options: CARD_BORDERS,
+      table: {
+        category: "inputs",
+        type: { summary: "CardBorderType" },
+        defaultValue: { summary: "undefined" },
+      },
+    },
+    xs: {
+      description: "Overrides inputs on xs breakpoint (<576px).",
+      control: false,
+      table: { category: "inputs", type: { summary: "CardInputs" } },
+    },
+    sm: {
+      description: "Overrides inputs on sm breakpoint (≥576px).",
+      control: false,
+      table: { category: "inputs", type: { summary: "CardInputs" } },
+    },
+    md: {
+      description: "Overrides inputs on md breakpoint (≥768px).",
+      control: false,
+      table: { category: "inputs", type: { summary: "CardInputs" } },
+    },
+    lg: {
+      description: "Overrides inputs on lg breakpoint (≥992px).",
+      control: false,
+      table: { category: "inputs", type: { summary: "CardInputs" } },
+    },
+    xl: {
+      description: "Overrides inputs on xl breakpoint (≥1200px).",
+      control: false,
+      table: { category: "inputs", type: { summary: "CardInputs" } },
+    },
+    xxl: {
+      description: "Overrides inputs on xxl breakpoint (≥1400px).",
+      control: false,
+      table: { category: "inputs", type: { summary: "CardInputs" } },
+    },
+  },
+} as Meta<CardComponent>;
+
+type Story = StoryObj<CardComponent>;
+
+export const Default: Story = {
+  args: {
+    borderless: false,
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <tedi-card ${argsToTemplate(args)}>
+        <tedi-card-content>
+          <p tedi-text color="secondary">Kirjeldus</p>
+        </tedi-card-content>
+      </tedi-card>
+    `,
+  }),
+};
+
+export const HeaderTypes: Story = {
+  render: () => ({
+    template: `
+      <div [tediVerticalSpacing]="1">
+        <tedi-card>
+          <tedi-card-header background="primary">
+            <h3 tedi-text>Pealkiri</h3>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="primary">
+            <h3 tedi-text>Pealkiri</h3>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="primary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text>Pealkiri</h3>
+              <button tedi-button>Loo</button>
+            </div>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="primary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text>Pealkiri</h3>
+              <div class="flex gap-3">
+                <button tedi-button variant="secondary">
+                  <tedi-icon name="share" />
+                  Jaga
+                </button>
+                <button tedi-button variant="secondary">
+                  <tedi-icon name="print" />
+                  Prindi
+                </button>
+              </div>
+            </div>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="primary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text>Pealkiri</h3>
+              <a tedi-link href="#">
+                Vaata tulemust
+                <tedi-icon name="arrow_right_alt" />
+              </a>
+            </div>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="primary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text>Pealkiri</h3>
+              <tedi-status-badge color="brand" text="Kinnitatud" />
+            </div>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="secondary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text>Pealkiri</h3>
+              <button tedi-button>Loo</button>
+            </div>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="tertiary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text>Pealkiri</h3>
+              <button tedi-button>Loo</button>
+            </div>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="brand-primary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text color="white">Pealkiri</h3>
+              <button tedi-button variant="primary-inverted">Loo</button>
+            </div>
+            <p tedi-text color="white">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-header background="brand-secondary">
+            <div class="flex align-items-center justify-content-between gap-3">
+              <h3 tedi-text color="white">Pealkiri</h3>
+              <button tedi-button variant="primary-inverted">Loo</button>
+            </div>
+            <p tedi-text color="white">Kirjeldus</p>
+          </tedi-card-header>
+        </tedi-card>
+      </div>
+    `,
+  }),
+};
+
+export const CardSimple: Story = {
+  render: () => ({
+    template: `
+      <div [tediVerticalSpacing]="1">
+        <tedi-card>
+          <tedi-card-content>
+            <p tedi-text color="secondary">Kirjeldus</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-content>
+            <p tedi-text color="secondary">Kirjeldus</p>
+            <tedi-status-badge color="brand" text="Kinnitatud" />
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-content>
+            <p tedi-text modifiers="bold">Pealkiri</p>
+            <div class="flex align-items-center justify-content-between gap-3">
+              <p tedi-text color="secondary">Kirjeldus</p>
+              <tedi-status-badge color="brand" text="Kinnitatud" />
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-content>
+            <div class="flex align-items-center gap-3">
+              <tedi-icon name="monitor_heart" />
+              <p tedi-text color="secondary">Kirjeldus</p>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-content>
+            <div class="flex align-items-center gap-3">
+              <tedi-icon name="monitor_heart" />
+              <div>
+                <p tedi-text modifiers="bold">Pealkiri</p>
+                <p tedi-text color="secondary">Kirjeldus</p>
+              </div>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-content>
+            <div class="flex align-items-center justify-content-between gap-3">
+              <div class="flex align-items-center gap-3">
+                <tedi-icon name="monitor_heart" />
+                <div>
+                  <p tedi-text modifiers="bold">Pealkiri</p>
+                  <p tedi-text color="secondary">Kirjeldus</p>
+                </div>
+              </div>
+              <button tedi-button>Loo</button>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-row [cols]="1" [lg]="{ cols: 2 }">
+          <tedi-col>
+            <tedi-card>
+              <tedi-card-content>
+                <p tedi-text modifiers="bold">Pealkiri</p>
+                <p tedi-text color="secondary">Kirjeldus</p>
+                <tedi-separator [spacing]="1.5" />
+                <div class="flex justify-content-center">
+                  <button tedi-button>Loo</button>
+                </div>
+              </tedi-card-content>
+            </tedi-card>
+          </tedi-col>
+        </tedi-row>
+      </div>
+    `,
+  }),
+};
+
+export const CardInfo: Story = {
+  render: () => ({
+    template: `
+      <div [tediVerticalSpacing]="1">
+        <tedi-card>
+          <tedi-card-content background="brand-tertiary">
+            <div class="flex align-items-center gap-3">
+              <tedi-icon name="assignment_late" background="primary" />
+              <div>
+                <p tedi-text modifiers="bold">Pealkiri</p>
+                <p tedi-text color="secondary">Kirjeldus</p>
+              </div>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-content
+            background="brand-tertiary"
+            backgroundImage="card-background-example.svg"
+            backgroundSize="75px"
+            backgroundPosition="right center"
+            backgroundRepeat="no-repeat"
+          >
+            <div class="flex align-items-center gap-3">
+              <tedi-icon name="assignment_late" background="primary" />
+              <div>
+                <p tedi-text modifiers="bold">Pealkiri</p>
+                <p tedi-text color="secondary">Kirjeldus</p>
+              </div>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card border="accent">
+          <tedi-card-content background="accent">
+            <div class="flex align-items-center gap-3">
+              <tedi-icon name="assignment_late" background="primary" />
+              <div>
+                <p tedi-text modifiers="bold">Pealkiri</p>
+                <p tedi-text color="secondary">Kirjeldus</p>
+              </div>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card border="neutral-primary">
+          <tedi-card-content background="neutral-primary">
+            <div class="flex align-items-center gap-3">
+              <tedi-icon name="calendar_today" background="primary" variant="filled" />
+              <p tedi-text color="secondary">Haigusleht: <strong>118.</strong> päev</p>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+      </div>
+    `,
+  }),
+};
+
+export const AlternativeCards: Story = {
+  render: () => ({
+    template: `
+      <div [tediVerticalSpacing]="1">
+        <tedi-row [cols]="1" [lg]="{ cols: 2 }" [gap]="1">
+          <tedi-col>
+            <tedi-card>
+              <tedi-card-content>
+                <div [tediVerticalSpacing]="0.5">
+                  <div class="flex align-items-center gap-3">
+                    <tedi-icon name="assignment_ind" color="brand" />
+                    <h3 tedi-text color="brand">Minu tahteavaldus</h3>
+                  </div>
+                  <p tedi-text color="secondary">Näiteks elundidoonorlus ja vereülekanne</p>
+                </div>
+                <tedi-separator [spacing]="1" />
+                <button tedi-button variant="secondary">Vaata tahteavaldusi</button>
+              </tedi-card-content>
+            </tedi-card>
+          </tedi-col>
+          <tedi-col>
+            <tedi-card>
+              <tedi-card-content>
+                <div [tediVerticalSpacing]="1">
+                  <div [tediVerticalSpacing]="0.5">
+                    <p tedi-text modifiers="bold">Pealkiri</p>
+                    <p tedi-text color="secondary">Näiteks elundidoonorlus ja vereülekanne</p>
+                  </div>
+                  <button tedi-button variant="secondary">Vaata tahteavaldusi</button>
+                </div>
+              </tedi-card-content>
+            </tedi-card>
+          </tedi-col>
+          <tedi-col>
+            <tedi-card>
+              <tedi-card-header background="brand-primary">
+                <h3 tedi-text color="white">Lühike pealkiri</h3>
+              </tedi-card-header>
+              <tedi-card-content>
+                <div [tediVerticalSpacing]="1">
+                  <p tedi-text color="secondary">Näiteks elundidoonorlus ja vereülekanne</p>
+                  <button tedi-button variant="secondary">Vaata tahteavaldusi</button>
+                </div>
+              </tedi-card-content>
+            </tedi-card>
+          </tedi-col>
+          <tedi-col>
+            <tedi-card>
+              <tedi-card-content>
+                <div [tediVerticalSpacing]="1">
+                  <p tedi-text color="secondary">Näiteks elundidoonorlus ja vereülekanne</p>
+                  <button tedi-button variant="secondary">Vaata tahteavaldusi</button>
+                </div>
+              </tedi-card-content>
+            </tedi-card>
+          </tedi-col>
+        </tedi-row>
+        <tedi-card border="left-danger-secondary">
+          <tedi-card-content>
+            <p tedi-text>Tähtis kaart</p>
+          </tedi-card-content>
+        </tedi-card>
+      </div>
+    `,
+  }),
+};
+
+export const Spacing: Story = {
+  render: () => ({
+    props: { CABBAGE_TEXT },
+    template: `
+      <tedi-row [cols]="1" [lg]="{ cols: 3 }" [gap]="1">
+        <tedi-col>
+          <tedi-card>
+            <tedi-card-content [padding]="0.5">
+              <p tedi-text>{{ CABBAGE_TEXT }}</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card>
+            <tedi-card-content [padding]="1">
+              <p tedi-text>{{ CABBAGE_TEXT }}</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card>
+            <tedi-card-content [padding]="1.5">
+              <p tedi-text>{{ CABBAGE_TEXT }}</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const Border: Story = {
+  render: () => ({
+    template: `
+      <tedi-row [cols]="1" [lg]="{ cols: 2 }" [gap]="1">
+        <tedi-col>
+          <tedi-card>
+            <tedi-card-content>
+              <p tedi-text>Äärisega</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderless]="true">
+            <tedi-card-content>
+              <p tedi-text>Ääriseta</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const BorderRadius: Story = {
+  render: () => ({
+    template: `
+      <tedi-row [cols]="1" [lg]="{ cols: 4 }" [gap]="1">
+        <tedi-col>
+          <tedi-card>
+            <tedi-card-content>
+              <p tedi-text>Vaikimisi raadius</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderRadius]="false">
+            <tedi-card-content>
+              <p tedi-text>Raadius puudub</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderRadius]="{ top: false }">
+            <tedi-card-content>
+              <p tedi-text>Ülemine raadius puudub</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderRadius]="{ bottom: false }">
+            <tedi-card-content>
+              <p tedi-text>Alumine raadius puudub</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderRadius]="{ left: false }">
+            <tedi-card-content>
+              <p tedi-text>Vasak raadius puudub</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderRadius]="{ right: false }">
+            <tedi-card-content>
+              <p tedi-text>Parem raadius puudub</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderRadius]="{ topLeft: false }">
+            <tedi-card-content>
+              <p tedi-text>Vasak ülanurk puudub</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-col>
+          <tedi-card [borderRadius]="{ bottomRight: false }">
+            <tedi-card-content>
+              <p tedi-text>Parem alanurk puudub</p>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const Backgrounds: Story = {
+  render: () => ({
+    props: { CABBAGE_TEXT },
+    template: `
+      <tedi-row [cols]="1" [lg]="{ cols: 3 }" [gap]="1">
+        <tedi-card background="primary">
+          <tedi-card-content>
+            <p tedi-text>{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="secondary" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text>{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="tertiary" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text>{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="brand-primary" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text color="white">{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="brand-secondary" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text color="white">{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="brand-tertiary" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text>{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="brand-quaternary" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text>{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="success-primary" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text>{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-card background="accent" [borderless]="true">
+          <tedi-card-content>
+            <p tedi-text>{{ CABBAGE_TEXT }}</p>
+          </tedi-card-content>
+        </tedi-card>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const MultipleContent: Story = {
+  render: () => ({
+    template: `
+      <tedi-card>
+        <tedi-card-header background="brand-primary">
+          <h3 tedi-text color="white">Pealkiri</h3>
+        </tedi-card-header>
+        <tedi-card-content>
+          <p tedi-text>Esimene sisuplokk</p>
+        </tedi-card-content>
+        <tedi-separator />
+        <tedi-card-content>
+          <p tedi-text>Teine sisuplokk</p>
+        </tedi-card-content>
+        <tedi-separator />
+        <tedi-card-content>
+          <p tedi-text>Kolmas sisuplokk</p>
+        </tedi-card-content>
+      </tedi-card>
+    `,
+  }),
+};
+
+export const NestedCards: Story = {
+  render: () => ({
+    template: `
+      <tedi-card>
+        <tedi-card-header background="brand-primary">
+          <h3 tedi-text color="white">Pealkiri</h3>
+        </tedi-card-header>
+        <tedi-card-content>
+          <div [tediVerticalSpacing]="1">
+            <h4 tedi-text color="brand">Püsiravi</h4>
+            <p tedi-text>Sinu püsiravimid ja meditsiiniseadmed, mis on väljastatud viimase 6 kuu jooksul.</p>
+            <h5 tedi-text>Ravimid</h5>
+            <tedi-card [borderless]="true">
+              <tedi-card-content background="brand-tertiary">
+                <tedi-row [cols]="1" [md]="{ cols: 3 }" [gap]="1">
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>HJERTEMAGNYL TBL 150MG+21MG N100</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>150 MG+21 MG</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>Pidev ravi: 1 tk 1 kord nädalas</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                </tedi-row>
+              </tedi-card-content>
+            </tedi-card>
+            <tedi-card [borderless]="true">
+              <tedi-card-content background="brand-tertiary">
+                <tedi-row [cols]="1" [md]="{ cols: 3 }" [gap]="1">
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>HJERTEMAGNYL TBL 150MG+21MG N100</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>150 MG+21 MG</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>Pidev ravi: 1 tk 1 kord nädalas</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                </tedi-row>
+              </tedi-card-content>
+            </tedi-card>
+            <tedi-card [borderless]="true">
+              <tedi-card-content background="brand-tertiary">
+                <tedi-row [cols]="1" [md]="{ cols: 3 }" [gap]="1">
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>HJERTEMAGNYL TBL 150MG+21MG N100</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>150 MG+21 MG</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>Pidev ravi: 1 tk 1 kord nädalas</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                </tedi-row>
+              </tedi-card-content>
+            </tedi-card>
+          </div>
+        </tedi-card-content>
+        <tedi-separator />
+        <tedi-card-content>
+          <div [tediVerticalSpacing]="1">
+            <h4 tedi-text color="brand">Ajutine ravi</h4>
+            <p tedi-text>Sinu ravimid ja meditsiiniseadmed, mida kasutatakse vajadusel või teatud perioodil.</p>
+            <h5 tedi-text>Ravimid</h5>
+            <tedi-card [borderless]="true">
+              <tedi-card-content background="brand-tertiary">
+                <tedi-row [cols]="1" [md]="{ cols: 3 }" [gap]="1">
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>HJERTEMAGNYL TBL 150MG+21MG N100</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>150 MG+21 MG</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>Pidev ravi: 1 tk 1 kord nädalas</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                </tedi-row>
+              </tedi-card-content>
+            </tedi-card>
+            <tedi-card [borderless]="true">
+              <tedi-card-content background="brand-tertiary">
+                <tedi-row [cols]="1" [md]="{ cols: 3 }" [gap]="1">
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>HJERTEMAGNYL TBL 150MG+21MG N100</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>150 MG+21 MG</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                  <tedi-col>
+                    <tedi-text-group type="vertical">
+                      <tedi-text-group-label>Silt</tedi-text-group-label>
+                      <tedi-text-group-value>Pidev ravi: 1 tk 1 kord nädalas</tedi-text-group-value>
+                    </tedi-text-group>
+                  </tedi-col>
+                </tedi-row>
+              </tedi-card-content>
+            </tedi-card>
+          </div>
+        </tedi-card-content>
+      </tedi-card>
+    `,
+  }),
+};
+
+export const WithDottedSeparator: Story = {
+  render: () => ({
+    template: `
+      <tedi-card>
+        <tedi-card-row>
+          <tedi-card-icon>
+            <tedi-icon name="monitor_heart" />
+          </tedi-card-icon>
+          <tedi-separator axis="vertical" color="accent" variant="dotted-small" size="auto" />
+          <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+            <div>
+              <p tedi-text modifiers="bold">COVID-19</p>
+              <tedi-collapse openText="Näita kokkuvõtet" closeText="Peida kokkuvõte">
+                <p tedi-text color="secondary">
+                  COVID-19 vastane immuniseerimine, lõpetatud 08.12.2024.
+                </p>
+              </tedi-collapse>
+            </div>
+            <a tedi-link href="#">
+              Vaata
+              <tedi-icon name="arrow_right_alt" />
+            </a>
+          </tedi-card-content>
+        </tedi-card-row>
+        <tedi-separator />
+        <tedi-card-row>
+          <tedi-card-icon>
+            <tedi-icon name="monitor_heart" />
+          </tedi-card-icon>
+          <tedi-separator axis="vertical" color="accent" variant="dotted-small" size="auto" />
+          <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+            <div>
+              <p tedi-text modifiers="bold">COVID-19</p>
+              <tedi-collapse openText="Näita kokkuvõtet" closeText="Peida kokkuvõte">
+                <p tedi-text color="secondary">
+                  COVID-19 vastane immuniseerimine, lõpetatud 08.12.2024.
+                </p>
+              </tedi-collapse>
+            </div>
+            <a tedi-link href="#">
+              Vaata
+              <tedi-icon name="arrow_right_alt" />
+            </a>
+          </tedi-card-content>
+        </tedi-card-row>
+        <tedi-separator />
+        <tedi-card-row>
+          <tedi-card-icon>
+            <tedi-icon name="monitor_heart" />
+          </tedi-card-icon>
+          <tedi-separator axis="vertical" color="accent" variant="dotted-small" size="auto" />
+          <tedi-card-content class="flex align-items-center justify-content-between gap-3">
+            <div>
+              <p tedi-text modifiers="bold">COVID-19</p>
+              <tedi-collapse openText="Näita kokkuvõtet" closeText="Peida kokkuvõte">
+                <p tedi-text color="secondary">
+                  COVID-19 vastane immuniseerimine, lõpetatud 08.12.2024.
+                </p>
+              </tedi-collapse>
+            </div>
+            <a tedi-link href="#">
+              Vaata
+              <tedi-icon name="arrow_right_alt" />
+            </a>
+          </tedi-card-content>
+        </tedi-card-row>
+      </tedi-card>
+    `,
+  }),
+};
+
+export const CardIcon: Story = {
+  render: () => ({
+    template: `
+      <tedi-row [cols]="1" [lg]="{ cols: 2 }" [gap]="1">
+        <tedi-card>
+          <tedi-card-row>
+            <tedi-card-icon>
+              <tedi-icon name="monitor_heart" />
+            </tedi-card-icon>
+            <tedi-card-content>
+              <p tedi-text modifiers="bold">Vaikimisi</p>
+              <p tedi-text color="secondary">Kirjeldus</p>
+            </tedi-card-content>
+          </tedi-card-row>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-row>
+            <tedi-card-icon type="brand">
+              <tedi-icon name="monitor_heart" />
+            </tedi-card-icon>
+            <tedi-card-content>
+              <p tedi-text modifiers="bold">Bränd</p>
+              <p tedi-text color="secondary">Kirjeldus</p>
+            </tedi-card-content>
+          </tedi-card-row>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-row>
+            <tedi-card-icon size="small">
+              <tedi-icon name="monitor_heart" [size]="16" />
+            </tedi-card-icon>
+            <tedi-card-content>
+              <p tedi-text modifiers="bold">Väike</p>
+              <p tedi-text color="secondary">Kirjeldus</p>
+            </tedi-card-content>
+          </tedi-card-row>
+        </tedi-card>
+        <tedi-card>
+          <tedi-card-row>
+            <tedi-card-icon type="brand" size="small">
+              <tedi-icon name="monitor_heart" [size]="16" />
+            </tedi-card-icon>
+            <tedi-card-content>
+              <p tedi-text modifiers="bold">Väike bränd</p>
+              <p tedi-text color="secondary">Kirjeldus</p>
+            </tedi-card-content>
+          </tedi-card-row>
+        </tedi-card>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const PrescriptionExample: Story = {
+  render: () => ({
+    template: `
+      <tedi-card background="secondary">
+        <tedi-card-row>
+          <tedi-card-icon type="brand">
+            <tedi-icon name="prescriptions" />
+          </tedi-card-icon>
+          <tedi-card-content>
+            <div [tediVerticalSpacing]="1">
+              <div class="flex justify-content-between gap-3">
+                <div class="flex align-items-center gap-2">
+                  <p tedi-text modifiers="bold">Amlodipiin 50mg:</p>
+                  <p tedi-text>Amlodipin-rathiopharm 50mg</p>
+                  <button tedi-info-button></button>
+                </div>
+                <div [tediVerticalSpacing]="0.25" class="text-right">
+                  <p tedi-text><a tedi-link href="#">Vaata retsepti</a></p>
+                  <p tedi-text modifiers="small" color="secondary">Kehtiv kuni 12.05.2024</p>
+                </div>
+              </div>
+              <tedi-collapse openText="Välja ostmata 5 / 6 retsepti" closeText="Välja ostmata 5 / 6 retsepti" [defaultOpen]="true">
+              <tedi-row [cols]="1" [lg]="{ cols: 2 }" [gap]="1">
+                <tedi-card>
+                  <tedi-card-row>
+                    <tedi-card-icon type="brand" size="small">
+                      <tedi-icon name="prescriptions" [size]="16" />
+                    </tedi-card-icon>
+                    <tedi-card-content [padding]="0.5" class="flex align-items-center gap-2">
+                      <p tedi-text>Amlodipiin</p>
+                      <tedi-separator axis="vertical" size="auto" />
+                      <p tedi-text>30 tk</p>
+                    </tedi-card-content>
+                  </tedi-card-row>
+                </tedi-card>
+                <tedi-card>
+                  <tedi-card-row>
+                    <tedi-card-icon type="brand" size="small">
+                      <tedi-icon name="prescriptions" [size]="16" />
+                    </tedi-card-icon>
+                    <tedi-card-content [padding]="0.5" class="flex align-items-center gap-2">
+                      <p tedi-text>Amlodipiin</p>
+                      <tedi-separator axis="vertical" size="auto" />
+                      <p tedi-text>30 tk</p>
+                    </tedi-card-content>
+                  </tedi-card-row>
+                </tedi-card>
+                <tedi-card>
+                  <tedi-card-row>
+                    <tedi-card-icon type="brand" size="small">
+                      <tedi-icon name="prescriptions" [size]="16" />
+                    </tedi-card-icon>
+                    <tedi-card-content [padding]="0.5" class="flex align-items-center gap-2">
+                      <p tedi-text>Amlodipiin</p>
+                      <tedi-separator axis="vertical" size="auto" />
+                      <p tedi-text>30 tk</p>
+                    </tedi-card-content>
+                  </tedi-card-row>
+                </tedi-card>
+                <tedi-card>
+                  <tedi-card-row>
+                    <tedi-card-icon size="small">
+                      <tedi-icon name="check_box" [size]="16" />
+                    </tedi-card-icon>
+                    <tedi-separator axis="vertical" size="auto" />
+                    <tedi-card-content [padding]="0.5" class="flex align-items-center gap-2">
+                      <p tedi-text>Amlodipiin</p>
+                      <tedi-separator axis="vertical" size="auto" />
+                      <p tedi-text>30 tk</p>
+                      <tedi-status-badge text="Ostetud 12.04.2024" />
+                    </tedi-card-content>
+                  </tedi-card-row>
+                </tedi-card>
+              </tedi-row>
+              </tedi-collapse>
+            </div>
+          </tedi-card-content>
+        </tedi-card-row>
+      </tedi-card>
+    `,
+  }),
+};
+
+export const SplitCardBody: Story = {
+  render: () => ({
+    template: `
+      <tedi-card>
+        <tedi-card-row>
+          <tedi-card-content>
+            <p tedi-text>Vasak</p>
+            <p tedi-text>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. In
+              convallis mollis augue, vitae aliquet elit congue a. Donec
+              vitae sagittis odio, et maximus nulla. Quisque metus augue,
+              euismod non auctor sed, consequat in ligula.
+            </p>
+          </tedi-card-content>
+          <tedi-card-content background="secondary">
+            <p tedi-text>Parem</p>
+          </tedi-card-content>
+        </tedi-card-row>
+      </tedi-card>
+    `,
+  }),
+};
+
+export const TwoTonedCard: Story = {
+  render: () => ({
+    template: `
+      <tedi-card>
+        <tedi-card-row>
+          <tedi-card-icon>
+            <tedi-icon name="straighten" />
+          </tedi-card-icon>
+          <tedi-separator axis="vertical" size="auto" />
+          <tedi-card-content>
+            <p tedi-text modifiers="bold">Statistika: x kg</p>
+            <p tedi-text>Kirjeldus</p>
+          </tedi-card-content>
+        </tedi-card-row>
+      </tedi-card>
+    `,
+  }),
+};
+
+const LOREM_TEXT =
+  "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Ab ad expedita iste itaque laborum magnam non nulla tempora ullam! A consequuntur dicta et incidunt nisi pariatur sapiente, temporibus unde voluptatem?";
+
+export const EqualHeight: Story = {
+  render: () => ({
+    props: { LOREM_TEXT },
+    template: `
+      <tedi-row [cols]="1" [lg]="{ cols: 3 }" [gap]="1">
+        <tedi-card>
+          <tedi-card-header background="brand-primary">
+            <h2 tedi-text color="white">Pikema sisuga kaart</h2>
+          </tedi-card-header>
+          <tedi-card-content class="flex flex-column justify-content-between gap-3">
+            <div [tediVerticalSpacing]="1">
+              <p tedi-text>{{ LOREM_TEXT }}</p>
+              <p tedi-text>{{ LOREM_TEXT }}</p>
+            </div>
+            <div>
+              <button tedi-button>Vajuta mind</button>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+        <tedi-col>
+          <tedi-card>
+            <tedi-card-header background="brand-primary">
+              <h2 tedi-text color="white">Venitamata kaart</h2>
+            </tedi-card-header>
+            <tedi-card-content class="flex flex-column justify-content-between gap-3">
+              <p tedi-text>{{ LOREM_TEXT }}</p>
+              <div>
+                <button tedi-button>Vajuta mind</button>
+              </div>
+            </tedi-card-content>
+          </tedi-card>
+        </tedi-col>
+        <tedi-card>
+          <tedi-card-header background="brand-primary">
+            <h2 tedi-text color="white">Venitatud sisuga kaart</h2>
+          </tedi-card-header>
+          <tedi-card-content class="flex flex-column justify-content-between gap-3">
+            <p tedi-text>{{ LOREM_TEXT }}</p>
+            <div>
+              <button tedi-button>Vajuta mind</button>
+            </div>
+          </tedi-card-content>
+        </tedi-card>
+      </tedi-row>
+    `,
+  }),
+};
+
+export const WithNotification: Story = {
+  render: () => ({
+    template: `
+      <tedi-card [padding]="0.75">
+        <tedi-card-header background="primary">
+          <h3 tedi-text>Kaardi pealkiri</h3>
+        </tedi-card-header>
+        <tedi-alert variant="noSideBorders">
+          <p tedi-text>Kaardi teavitus</p>
+        </tedi-alert>
+        <tedi-card-content>
+          <p tedi-text color="secondary">Kirjeldus</p>
+        </tedi-card-content>
+      </tedi-card>
+    `,
+  }),
+};
+
+export const BreakpointProps: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Padding and background change at md and lg breakpoints. Resize the viewport to see the effect.",
+      },
+    },
+  },
+  render: () => ({
+    props: { CABBAGE_TEXT },
+    template: `
+      <tedi-card
+        [padding]="0.5"
+        [md]="{ padding: 1.5, background: 'brand-tertiary' }"
+        [lg]="{ padding: 2.5, background: 'success-primary' }"
+      >
+        <tedi-card-content>
+          <p tedi-text>{{ CABBAGE_TEXT }}</p>
+        </tedi-card-content>
+      </tedi-card>
+    `,
+  }),
+};

--- a/tedi/components/content/card/card.utils.ts
+++ b/tedi/components/content/card/card.utils.ts
@@ -1,0 +1,134 @@
+export type CardBorderPlacement = "top" | "left";
+
+export type CardBackground =
+  | "primary"
+  | "secondary"
+  | "tertiary"
+  | "accent"
+  | "brand-primary"
+  | "brand-secondary"
+  | "brand-tertiary"
+  | "brand-quaternary"
+  | "danger-primary"
+  | "danger-secondary"
+  | "success-primary"
+  | "success-secondary"
+  | "info-primary"
+  | "info-secondary"
+  | "warning-primary"
+  | "warning-secondary"
+  | "neutral-primary"
+  | "neutral-secondary";
+
+export type CardBorderType =
+  | `${CardBorderPlacement}-${CardBackground}`
+  | CardBackground;
+
+export type CardPaddingNumber = 0 | 0.5 | 0.75 | 1 | 1.5 | 2 | 2.5 | 3;
+
+export type CardPadding =
+  | CardPaddingNumber
+  | { vertical: CardPaddingNumber; horizontal: CardPaddingNumber }
+  | {
+      top?: CardPaddingNumber;
+      right?: CardPaddingNumber;
+      bottom?: CardPaddingNumber;
+      left?: CardPaddingNumber;
+    };
+
+export type CardBorderRadius =
+  | false
+  | {
+      top?: boolean;
+      right?: boolean;
+      bottom?: boolean;
+      left?: boolean;
+      topLeft?: boolean;
+      topRight?: boolean;
+      bottomRight?: boolean;
+      bottomLeft?: boolean;
+    };
+
+export type CardResolvedCorners = {
+  topLeft: boolean;
+  topRight: boolean;
+  bottomRight: boolean;
+  bottomLeft: boolean;
+};
+
+export function getCardBorderPlacementColor(
+  border?: CardBorderType,
+): [CardBorderPlacement | undefined, CardBackground | undefined] {
+  if (!border) {
+    return [undefined, undefined];
+  }
+
+  if (border.startsWith("top-")) {
+    return ["top", border.slice("top-".length) as CardBackground];
+  }
+
+  if (border.startsWith("left-")) {
+    return ["left", border.slice("left-".length) as CardBackground];
+  }
+
+  return [undefined, border as CardBackground];
+}
+
+export function getPaddingCssVariables(
+  padding: CardPadding,
+): Record<string, string> {
+  if (typeof padding === "number") {
+    return {
+      "--card-content-padding-top": `${padding}rem`,
+      "--card-content-padding-right": `${padding}rem`,
+      "--card-content-padding-bottom": `${padding}rem`,
+      "--card-content-padding-left": `${padding}rem`,
+    };
+  }
+
+  if ("vertical" in padding && "horizontal" in padding) {
+    return {
+      "--card-content-padding-top": `${padding.vertical}rem`,
+      "--card-content-padding-right": `${padding.horizontal}rem`,
+      "--card-content-padding-bottom": `${padding.vertical}rem`,
+      "--card-content-padding-left": `${padding.horizontal}rem`,
+    };
+  }
+
+  const { top = 0, right = 0, bottom = 0, left = 0 } = padding;
+  return {
+    "--card-content-padding-top": `${top}rem`,
+    "--card-content-padding-right": `${right}rem`,
+    "--card-content-padding-bottom": `${bottom}rem`,
+    "--card-content-padding-left": `${left}rem`,
+  };
+}
+
+export function resolveCardBorderRadius(
+  config?: CardBorderRadius,
+): CardResolvedCorners {
+  if (config === false) {
+    return {
+      topLeft: false,
+      topRight: false,
+      bottomRight: false,
+      bottomLeft: false,
+    };
+  }
+
+  const { top, right, bottom, left, topLeft, topRight, bottomRight, bottomLeft } =
+    config ?? {};
+
+  const sideTop = top !== false;
+  const sideRight = right !== false;
+  const sideBottom = bottom !== false;
+  const sideLeft = left !== false;
+
+  // corner overrides take precedence over side values
+  return {
+    topLeft: topLeft ?? (sideTop && sideLeft),
+    topRight: topRight ?? (sideTop && sideRight),
+    bottomRight: bottomRight ?? (sideBottom && sideRight),
+    bottomLeft: bottomLeft ?? (sideBottom && sideLeft),
+  };
+}

--- a/tedi/components/content/card/index.ts
+++ b/tedi/components/content/card/index.ts
@@ -1,0 +1,6 @@
+export * from "./card.component";
+export * from "./card.utils";
+export * from "./card-content";
+export * from "./card-icon";
+export * from "./card-row";
+export * from "./card-header";

--- a/tedi/components/content/index.ts
+++ b/tedi/components/content/index.ts
@@ -1,3 +1,4 @@
+export * from "./card";
 export * from "./list/list.component";
 export * from "./text-group/";
 export * from "./carousel";

--- a/tedi/components/helpers/timeline/index.ts
+++ b/tedi/components/helpers/timeline/index.ts
@@ -1,4 +1,5 @@
 export * from "./timeline.component";
+export * from "./timeline-timings-bottom.directive";
 export * from "./timeline-item/timeline-item.component";
 export * from "./timeline-description/timeline-description.component";
 export * from "./timeline-title/timeline-title.component";

--- a/tedi/components/helpers/timeline/timeline-item/timeline-item.component.html
+++ b/tedi/components/helpers/timeline/timeline-item/timeline-item.component.html
@@ -4,6 +4,11 @@
       {{ timing }}
     </div>
   }
+  @if (!isMobile() && timingsBottom()) {
+    <div class="tedi-timeline__timings-bottom">
+      <ng-container *ngTemplateOutlet="timingsBottom()!.templateRef" />
+    </div>
+  }
 </div>
 <div
   class="tedi-timeline__marker"
@@ -31,3 +36,8 @@
     <ng-content />
   </div>
 </div>
+@if (isMobile() && timingsBottom()) {
+  <div class="tedi-timeline__timings-bottom">
+    <ng-container *ngTemplateOutlet="timingsBottom()!.templateRef" />
+  </div>
+}

--- a/tedi/components/helpers/timeline/timeline-item/timeline-item.component.scss
+++ b/tedi/components/helpers/timeline/timeline-item/timeline-item.component.scss
@@ -23,6 +23,13 @@ tedi-timeline-item {
       padding-bottom: var(--timeline-padding-y);
     }
 
+    > .tedi-timeline__timings-bottom {
+      @include breakpoints.media-breakpoint-up(lg) {
+        margin-top: auto;
+        text-align: right;
+      }
+    }
+
     .tedi-timeline__time {
       position: relative;
       display: flex;
@@ -95,5 +102,15 @@ tedi-timeline-item {
     display: flex;
     flex-direction: column;
     gap: var(--timeline-padding-y);
+  }
+
+  > .tedi-timeline__timings-bottom {
+    grid-row: auto;
+    grid-column: 2;
+    padding-bottom: var(--timeline-padding-y);
+  }
+
+  &.tedi-timeline__item--has-bottom .tedi-timeline__marker {
+    grid-row: span 3;
   }
 }

--- a/tedi/components/helpers/timeline/timeline-item/timeline-item.component.ts
+++ b/tedi/components/helpers/timeline/timeline-item/timeline-item.component.ts
@@ -2,6 +2,7 @@ import {
   ChangeDetectionStrategy,
   Component,
   computed,
+  contentChild,
   inject,
   input,
   OnDestroy,
@@ -14,24 +15,33 @@ import {
 } from "../../separator/separator.component";
 import { TextComponent } from "../../../base/text/text.component";
 import { TimelineComponent } from "../timeline.component";
-import { NgClass } from "@angular/common";
+import { NgClass, NgTemplateOutlet } from "@angular/common";
+import { BreakpointService } from "../../../../services/breakpoint/breakpoint.service";
+import { TimelineTimingsBottomDirective } from "../timeline-timings-bottom.directive";
 
 type TimelineItemState = "current" | "past" | "future";
 
 @Component({
   standalone: true,
   selector: "tedi-timeline-item",
-  imports: [SeparatorComponent, TextComponent, NgClass],
+  imports: [SeparatorComponent, TextComponent, NgClass, NgTemplateOutlet],
   templateUrl: "./timeline-item.component.html",
   styleUrl: "./timeline-item.component.scss",
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    "[class.tedi-timeline__item--has-bottom]": "isMobile() && !!timingsBottom()",
+  },
 })
 export class TimelineItemComponent implements OnInit, OnDestroy {
   /** Item timings */
   timings = input<string[]>([]);
 
   timeline = inject(TimelineComponent, { optional: true });
+
+  protected isMobile = inject(BreakpointService).isBelowBreakpoint("lg");
+
+  protected timingsBottom = contentChild(TimelineTimingsBottomDirective);
 
   ngOnInit() {
     if (!this.timeline) {

--- a/tedi/components/helpers/timeline/timeline-item/timeline-item.component.ts
+++ b/tedi/components/helpers/timeline/timeline-item/timeline-item.component.ts
@@ -30,6 +30,7 @@ type TimelineItemState = "current" | "past" | "future";
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
+    class: "tedi-timeline-item",
     "[class.tedi-timeline__item--has-bottom]": "isMobile() && !!timingsBottom()",
   },
 })

--- a/tedi/components/helpers/timeline/timeline-timings-bottom.directive.ts
+++ b/tedi/components/helpers/timeline/timeline-timings-bottom.directive.ts
@@ -1,0 +1,15 @@
+import { Directive, inject, TemplateRef } from "@angular/core";
+
+/**
+ * Marks content that is pinned to the bottom of a timeline item's timings
+ * column on desktop and rendered after the item content on mobile.
+ *
+ * Usage: `<p *tediTimelineTimingsBottom>Muudetud 08.02.2024</p>`
+ */
+@Directive({
+  selector: "[tediTimelineTimingsBottom]",
+  standalone: true,
+})
+export class TimelineTimingsBottomDirective {
+  templateRef = inject(TemplateRef);
+}

--- a/tedi/components/helpers/timeline/timeline.component.scss
+++ b/tedi/components/helpers/timeline/timeline.component.scss
@@ -1,6 +1,6 @@
 @use "@tedi-design-system/core/bootstrap-utility/breakpoints";
 
-tedi-timeline {
+.tedi-timeline {
   display: grid;
   grid-template-columns: max-content 1fr;
   grid-auto-rows: auto;
@@ -21,7 +21,7 @@ tedi-timeline {
   border: 1px solid var(--card-border-primary);
   border-radius: var(--card-radius-rounded);
 
-  tedi-timeline-item {
+  .tedi-timeline-item {
     display: grid;
     grid-template-columns: subgrid;
     grid-column: 1 / -1;
@@ -29,11 +29,11 @@ tedi-timeline {
     border-bottom: 1px solid var(--card-border-primary);
   }
 
-  tedi-timeline-item:last-child {
+  .tedi-timeline-item:last-child {
     border-bottom: 0;
   }
 
-  tedi-timeline-item:not(:last-child) .tedi-timeline__marker {
+  .tedi-timeline-item:not(:last-child) .tedi-timeline__marker {
     margin-bottom: calc(-2 * var(--_timeline-card-padding) - 10px);
   }
 
@@ -42,11 +42,11 @@ tedi-timeline {
   }
 
   @include breakpoints.media-breakpoint-down(lg) {
-    tedi-timeline-item .tedi-timeline__marker {
+    .tedi-timeline-item .tedi-timeline__marker {
       grid-row: 1 / span 2;
     }
 
-    tedi-timeline-item.tedi-timeline__item--has-bottom .tedi-timeline__marker {
+    .tedi-timeline-item.tedi-timeline__item--has-bottom .tedi-timeline__marker {
       grid-row: 1 / span 3;
     }
   }

--- a/tedi/components/helpers/timeline/timeline.component.scss
+++ b/tedi/components/helpers/timeline/timeline.component.scss
@@ -13,3 +13,41 @@ tedi-timeline {
     row-gap: 0;
   }
 }
+
+.tedi-timeline--card {
+  --_timeline-card-padding: var(--card-padding-md-default);
+
+  background: var(--card-background-primary);
+  border: 1px solid var(--card-border-primary);
+  border-radius: var(--card-radius-rounded);
+
+  tedi-timeline-item {
+    display: grid;
+    grid-template-columns: subgrid;
+    grid-column: 1 / -1;
+    padding: var(--_timeline-card-padding);
+    border-bottom: 1px solid var(--card-border-primary);
+  }
+
+  tedi-timeline-item:last-child {
+    border-bottom: 0;
+  }
+
+  tedi-timeline-item:not(:last-child) .tedi-timeline__marker {
+    margin-bottom: calc(-2 * var(--_timeline-card-padding) - 10px);
+  }
+
+  .tedi-timeline__marker .tedi-separator--dot-only-outlined::before {
+    background-color: var(--card-background-primary);
+  }
+
+  @include breakpoints.media-breakpoint-down(lg) {
+    tedi-timeline-item .tedi-timeline__marker {
+      grid-row: 1 / span 2;
+    }
+
+    tedi-timeline-item.tedi-timeline__item--has-bottom .tedi-timeline__marker {
+      grid-row: 1 / span 3;
+    }
+  }
+}

--- a/tedi/components/helpers/timeline/timeline.component.spec.ts
+++ b/tedi/components/helpers/timeline/timeline.component.spec.ts
@@ -4,6 +4,7 @@ import { TimelineComponent } from "./timeline.component";
 import { TimelineItemComponent } from "./timeline-item/timeline-item.component";
 import { TimelineTitleComponent } from "./timeline-title/timeline-title.component";
 import { TimelineDescriptionComponent } from "./timeline-description/timeline-description.component";
+import { TimelineTimingsBottomDirective } from "./timeline-timings-bottom.directive";
 
 @Component({
   standalone: true,
@@ -36,6 +37,24 @@ class MultipleTimelineItemsHostComponent {
   items!: QueryList<TimelineItemComponent>;
 }
 
+@Component({
+  standalone: true,
+  imports: [
+    TimelineComponent,
+    TimelineItemComponent,
+    TimelineTimingsBottomDirective,
+  ],
+  template: `
+    <tedi-timeline>
+      <tedi-timeline-item [timings]="['2024']">
+        <span *tediTimelineTimingsBottom class="bottom">Muudetud</span>
+        Content
+      </tedi-timeline-item>
+    </tedi-timeline>
+  `,
+})
+class TimingsBottomHostComponent {}
+
 describe("Timeline Components", () => {
   let fixture: ComponentFixture<TimelineComponent>;
 
@@ -55,6 +74,33 @@ describe("Timeline Components", () => {
 
   it("should create TimelineComponent", () => {
     expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it("should project timings-bottom content into the timings column", () => {
+    const hostFixture = TestBed.createComponent(TimingsBottomHostComponent);
+    hostFixture.detectChanges();
+    const bottom = hostFixture.nativeElement.querySelector(
+      ".tedi-timeline__timings .bottom",
+    );
+    expect(bottom?.textContent).toContain("Muudetud");
+  });
+
+  it("should set card padding variable", () => {
+    fixture.componentRef.setInput("variant", "card");
+    fixture.componentRef.setInput("cardPadding", 0.75);
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.style.getPropertyValue("--_timeline-card-padding"),
+    ).toBe("0.75rem");
+  });
+
+  it("should apply card variant class", () => {
+    expect(fixture.nativeElement.classList).not.toContain(
+      "tedi-timeline--card",
+    );
+    fixture.componentRef.setInput("variant", "card");
+    fixture.detectChanges();
+    expect(fixture.nativeElement.classList).toContain("tedi-timeline--card");
   });
 
   it("should allow registering and unregistering items", () => {

--- a/tedi/components/helpers/timeline/timeline.component.ts
+++ b/tedi/components/helpers/timeline/timeline.component.ts
@@ -20,9 +20,10 @@ export type TimelineCardPadding = CardPaddingNumber;
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
   host: {
+    class: "tedi-timeline",
     "[class.tedi-timeline--card]": "variant() === 'card'",
     "[style.--_timeline-card-padding]":
-      "variant() === 'card' && cardPadding() ? cardPadding() + 'rem' : null",
+      "variant() === 'card' && cardPadding() != null ? cardPadding() + 'rem' : null",
   },
 })
 export class TimelineComponent {

--- a/tedi/components/helpers/timeline/timeline.component.ts
+++ b/tedi/components/helpers/timeline/timeline.component.ts
@@ -6,6 +6,11 @@ import {
   ViewEncapsulation,
 } from "@angular/core";
 import { TimelineItemComponent } from "./timeline-item/timeline-item.component";
+import { CardPaddingNumber } from "../../content/card/card.utils";
+
+export type TimelineVariant = "default" | "card";
+
+export type TimelineCardPadding = CardPaddingNumber;
 
 @Component({
   standalone: true,
@@ -14,10 +19,26 @@ import { TimelineItemComponent } from "./timeline-item/timeline-item.component";
   styleUrl: "./timeline.component.scss",
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    "[class.tedi-timeline--card]": "variant() === 'card'",
+    "[style.--_timeline-card-padding]":
+      "variant() === 'card' && cardPadding() ? cardPadding() + 'rem' : null",
+  },
 })
 export class TimelineComponent {
   /** Index of active item */
   activeIndex = input<number>();
+  /**
+   * Visual variant. "card" wraps the timeline in the borders and paddings
+   * of a card.
+   * @default default
+   */
+  variant = input<TimelineVariant>("default");
+  /**
+   * Item padding in rems for the card variant.
+   * @default 1
+   */
+  cardPadding = input<TimelineCardPadding>();
 
   items = signal<TimelineItemComponent[]>([]);
 

--- a/tedi/components/helpers/timeline/timeline.stories.ts
+++ b/tedi/components/helpers/timeline/timeline.stories.ts
@@ -4,6 +4,7 @@ import { TimelineComponent } from "./timeline.component";
 import { TimelineItemComponent } from "./timeline-item/timeline-item.component";
 import { TimelineTitleComponent } from "./timeline-title/timeline-title.component";
 import { TimelineDescriptionComponent } from "./timeline-description/timeline-description.component";
+import { TimelineTimingsBottomDirective } from "./timeline-timings-bottom.directive";
 import { CollapseComponent } from "../../buttons/collapse/collapse.component";
 import { TextComponent } from "../../base/text/text.component";
 import { ButtonComponent } from "../../buttons/button/button.component";
@@ -32,6 +33,7 @@ export default {
         TimelineItemComponent,
         TimelineTitleComponent,
         TimelineDescriptionComponent,
+        TimelineTimingsBottomDirective,
         CollapseComponent,
         TextComponent,
         ButtonComponent,
@@ -47,6 +49,28 @@ export default {
       table: {
         category: "timeline",
         type: { summary: "number" },
+      },
+    },
+    variant: {
+      description:
+        "Visual variant. 'card' wraps the timeline in the borders and paddings of a card.",
+      control: { type: "radio" },
+      options: ["default", "card"],
+      table: {
+        category: "timeline",
+        type: { summary: "TimelineVariant" },
+        defaultValue: { summary: "default" },
+      },
+    },
+    cardPadding: {
+      description:
+        "Item padding in rems for the card variant. Same values as the Card component.",
+      control: { type: "select" },
+      options: [0, 0.5, 0.75, 1, 1.5, 2, 2.5, 3],
+      table: {
+        category: "timeline",
+        type: { summary: "TimelineCardPadding" },
+        defaultValue: { summary: "1" },
       },
     },
     timings: {
@@ -65,11 +89,12 @@ type Story = StoryObj<TimelineComponent>;
 export const Default: Story = {
   args: {
     activeIndex: 2,
+    variant: "default",
   },
   render: (args) => ({
     props: args,
     template: `
-      <tedi-timeline [activeIndex]="activeIndex">
+      <tedi-timeline [activeIndex]="activeIndex" [variant]="variant" [cardPadding]="cardPadding">
         <tedi-timeline-item [timings]="['1990', '14. detsember']">
           <tedi-timeline-title>Staaži kogumise algus (I sammas)</tedi-timeline-title>
         </tedi-timeline-item>
@@ -282,6 +307,44 @@ export const WithMultipleDates: Story = {
         <tedi-timeline-item [timings]="['1991', '15. jaanuar']">
           <tedi-timeline-title>Otsus</tedi-timeline-title>
           <tedi-timeline-description>Otsus tehakse teatavaks.</tedi-timeline-description>
+        </tedi-timeline-item>
+      </tedi-timeline>
+    `,
+  }),
+};
+
+export const TimelineCard: Story = {
+  args: {
+    activeIndex: 1,
+    variant: "card",
+  },
+  render: (args) => ({
+    props: args,
+    template: `
+      <tedi-timeline [activeIndex]="activeIndex" [variant]="variant" [cardPadding]="cardPadding">
+        <tedi-timeline-item [timings]="['11.01.2024 12:23', 'Kersti Ööviul']">
+          <p *tediTimelineTimingsBottom tedi-text modifiers="small" color="tertiary">
+            Muudetud 08.02.2024 12:23
+          </p>
+          <tedi-timeline-title>Suhtlus isikuga</tedi-timeline-title>
+          <tedi-collapse openText="Näita rohkem" closeText="Näita vähem" [defaultOpen]="true">
+            <p tedi-text modifiers="small" color="secondary">Lisainfo: Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          </tedi-collapse>
+        </tedi-timeline-item>
+        <tedi-timeline-item [timings]="['08.02.2024 12:23', 'Kersti Ööviul']">
+          <p *tediTimelineTimingsBottom tedi-text modifiers="small" color="tertiary">
+            Muudetud 12.03.2024 12:23
+          </p>
+          <tedi-timeline-title>Suhtlus isikuga</tedi-timeline-title>
+          <tedi-collapse openText="Näita rohkem" closeText="Näita vähem">
+            <p tedi-text modifiers="small" color="secondary">Lisainfo: Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          </tedi-collapse>
+        </tedi-timeline-item>
+        <tedi-timeline-item [timings]="['12.05.2024 12:23', 'Kersti Ööviul']">
+          <tedi-timeline-title>Suhtlus isikuga</tedi-timeline-title>
+          <tedi-collapse openText="Näita rohkem" closeText="Näita vähem">
+            <p tedi-text modifiers="small" color="secondary">Lisainfo: Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
+          </tedi-collapse>
         </tedi-timeline-item>
       </tedi-timeline>
     `,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New TEDI-ready Card system: customizable backgrounds, padding, borders, border-radius, and responsive inputs.
  * New Card subcomponents: CardContent, CardHeader, CardIcon, CardRow, and an interactive CardButton wrapper.
  * Timeline: added a "card" variant and support for bottom-positioned timings on mobile.

* **Deprecations**
  * Community Card components marked deprecated in favor of TEDI-ready Card.

* **Documentation**
  * Updated component references and Storybook examples for Card, CardButton, and Timeline.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

# Migration Guide — Card

This release introduces a TEDI-Ready **Card** component family (`Card`, `CardContent`, `CardHeader`, `CardRow`, `CardIcon`) and a new **CardButton**, and deprecates the Community Card components. The Community Card (`@tedi-design-system/angular/community`) still works in this version but is marked `@deprecated` and will be removed in a future release. Both implementations use the same `tedi-card` selectors — migrate per component and **never mix imports of the two in one consuming component**.

## Import path

**What changed:** The Card family now lives in the TEDI-Ready entry point.

**Before:**

```ts
import {
  CardComponent,
  CardContentComponent,
  CardHeaderComponent,
  CardRowComponent,
} from "@tedi-design-system/angular/community";
```

**After:**

```ts
import {
  CardComponent,
  CardContentComponent,
  CardHeaderComponent,
  CardRowComponent,
  CardIconComponent,
} from "@tedi-design-system/angular/tedi";
```

## Card (container)

**What changed:** The card container moved from the Community entry point to TEDI-Ready with a reworked API: named `spacing` is replaced by rem-based `padding`, `accentBorder` is replaced by the more flexible `border`, and `selected` has no direct successor. `background`/`padding` set on the card now act as inheritable defaults for child blocks. New capabilities: `borderRadius` control per side/corner and responsive `xs`–`xxl` breakpoint overrides.

**Why:** Aligns the Angular Card with the TEDI design spec and the React implementation, with one shared token-based API across frameworks.

**Before:**

```html
<tedi-card spacing="lg" accentBorder="danger" [borderless]="false">
  ...
</tedi-card>
```

**After:**

```html
<tedi-card [padding]="1.5" border="left-danger-secondary" [borderless]="false">
  ...
</tedi-card>
```

**Key changes:**

- `spacing: "xs" | "sm" | "md" | "lg" | "none"` → `padding: CardPadding` in rems: `xs` → `0.5`, `sm` → `0.75`, `md` → `1` (default in both), `lg` → `1.5`, `none` → `0`; also accepts `{ vertical, horizontal }` or `{ top, right, bottom, left }` objects
- `accentBorder: "info" | "success" | "warning" | "danger"` → `border="left-info-secondary"` / `"left-success-secondary"` / `"left-warning-secondary"` / `"left-danger-secondary"` (same color tokens); `border` additionally supports `top-` accents and full-border coloring with any of the 18 background values
- `selected: boolean` — **removed, no direct equivalent.** For interactive/selectable card surfaces use the new `CardButton`; for a static selected outline apply project-level CSS
- `background` and `padding` set on `tedi-card` now cascade as defaults into child `tedi-card-content` blocks (Community required setting them per block or via directive inputs)
- New: `borderRadius` (`false` or per-side/per-corner object), responsive `xs`–`xxl` input objects

## CardContent

**What changed:** Same role, compatible core API; `padding` switches to rems and `timeline` is removed.

**Before:**

```html
<tedi-card-content background="brand-tertiary" padding="sm" [hasSeparator]="true" [autoWidth]="true">
  ...
</tedi-card-content>
```

**After:**

```html
<tedi-card-content background="brand-tertiary" [padding]="0.75" [autoWidth]="true">
  ...
</tedi-card-content>
<tedi-separator />
```

**Key changes:**

- `background` — same 18 values, unchanged
- `padding` — named values → rem numbers (mapping above); unset values now inherit from the parent `tedi-card`
- `autoWidth` — unchanged
- `hasSeparator: boolean` — **removed.** Place a `tedi-separator` element where the divider should appear: horizontal between content blocks/rows, `axis="vertical" size="auto"` between cells inside a `tedi-card-row`
- `timeline: boolean` — **removed.** For a card-styled timeline use `tedi-timeline variant="card"`; for a decorative dotted line between row cells place a vertical dotted `tedi-separator` between them
- New: `backgroundImage`/`backgroundPosition`/`backgroundSize`/`backgroundRepeat`, responsive `xs`–`xxl` inputs

## CardHeader

**What changed:** The `variant` input is replaced by the standard `background` input, and the header defaults to the brand background.

**Before:**

```html
<tedi-card-header variant="brand-dark">My header</tedi-card-header>
```

**After:**

```html
<tedi-card-header background="brand-secondary">
  <h3 tedi-text color="white">My header</h3>
</tedi-card-header>
```

**Key changes:**

- `variant: "primary" | "secondary" | "tertiary" | "brand" | "brand-dark"` → `background: CardBackground`: `primary` → `"primary"`, `secondary` → `"secondary"`, `tertiary` → `"tertiary"`, `brand` → `"brand-primary"`, `brand-dark` → `"brand-secondary"`
- The Community `brand` gradient header has no exact equivalent — TEDI-Ready `brand-primary` is a solid brand color
- Default changed: with no input, the header is now **brand-primary** (Community default was unstyled); on brand backgrounds use white text (`color="white"`) and `variant="primary-inverted"` buttons
- The attribute selector form (`[tedi-card-header]`) is gone — only the `tedi-card-header` element selector remains
- Header `background` deliberately does **not** inherit from the card

## CardRow

**What changed:** Same layout role; the `hasSeparator` input is removed in favor of explicit separators.

**Before:**

```html
<tedi-card-row hasSeparator>
  <tedi-card-content>Left</tedi-card-content>
  <tedi-card-content [hasSeparator]="true">Middle</tedi-card-content>
  <tedi-card-content>Right</tedi-card-content>
</tedi-card-row>
```

**After:**

```html
<tedi-card-row>
  <tedi-card-content>Left</tedi-card-content>
  <tedi-separator axis="vertical" size="auto" />
  <tedi-card-content>Middle</tedi-card-content>
  <tedi-card-content>Right</tedi-card-content>
</tedi-card-row>
<tedi-separator />
```

**Key changes:**

- `hasSeparator` (row and cell level) — **removed.** All dividers are plain `tedi-separator` elements
- Rows also accept the new `tedi-card-icon` cells and handle their corner radius automatically

## CardColorsDirective / CardPaddingDirective

**What changed:** Removed from the public API path. Their inputs are first-class inputs on the TEDI-Ready blocks.

**Key changes:**

- `background` → `background` input on `tedi-card` (inherited default) or per block
- `border` (full-border color) → `border` input on `tedi-card` with a plain background value (e.g. `border="accent"`)
- `padding` overrides (`padding-top-sm` style classes) → `padding` object input, e.g. `[padding]="{ top: 0, right: 1, bottom: 1, left: 1 }"`

## New in this release (no Community equivalent)

- **`tedi-card-icon`** — top-aligned icon cell for rows: `type="default" | "brand"`, `size="default" | "small"`; the projected `tedi-icon` inherits cell color
- **In-card notifications** — compose with the existing `tedi-alert`: `<tedi-alert variant="noSideBorders">` placed directly inside the card
- **CardButton** (`a[tedi-card-button]` / `button[tedi-card-button]`, Buttons category) — interactive wrapper around a `tedi-card` that applies hover/active/focus/disabled states to the card and its blocks; use an anchor host with `href`/`routerLink` for navigation or a button host for actions

## Summary table

| Community (`/community`) | TEDI-Ready (`/tedi`) |
|---|---|
| `tedi-card` `spacing="xs/sm/md/lg/none"` | `tedi-card` `[padding]="0.5 / 0.75 / 1 / 1.5 / 0"` |
| `tedi-card` `accentBorder="info/success/warning/danger"` | `tedi-card` `border="left-{info/success/warning/danger}-secondary"` |
| `tedi-card` `[selected]` | — removed (wrap the card in `CardButton` for interactive cards) |
| `tedi-card` `background` / `border` (directive) | `tedi-card` `background` / `border` inputs |
| `tedi-card-header` `variant="primary/secondary/tertiary"` | `tedi-card-header` `background="primary/secondary/tertiary"` |
| `tedi-card-header` `variant="brand"` / `"brand-dark"` | `tedi-card-header` `background="brand-primary"` / `"brand-secondary"` |
| `tedi-card-content` `padding="sm"` (named) | `tedi-card-content` `[padding]="0.75"` (rems) |
| `tedi-card-content` `[timeline]="true"` | — removed; use `tedi-timeline variant="card"` or a vertical dotted `tedi-separator` |
| `tedi-card-content` `[autoWidth]` | unchanged |
| `[hasSeparator]` (content/row) | — removed; place a `tedi-separator` element instead |
| `CardColorsDirective`, `CardPaddingDirective` | — removed; use block inputs |
| — | `tedi-card-icon`, `borderRadius`, `xs`–`xxl` breakpoints, `backgroundImage` (new) |
| — | `a/button[tedi-card-button]` clickable card (new) |
